### PR TITLE
Support running setupEM.py / setupThermal.py directly as scripts

### DIFF
--- a/src/setupEM/setupEM.py
+++ b/src/setupEM/setupEM.py
@@ -38,11 +38,20 @@ from PySide6.QtCore import Qt, QRegularExpression, QProcess, QRect, QStandardPat
 from gds2palace import *
 
 # shared building blocks used by both setupEM.py and setupThermal.py
-from .setup_common import (
-    EDIT_STYLE_OPTIONAL, EDIT_STYLE_REQUIRED, COMBO_STYLE_REQUIRED, COMBO_STYLE_OPTIONAL,
-    FileDropLineEdit, FileInputTab, PythonHighlighter, CodeEditor,
-    VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
-)
+# __package__ is None/"" when this file is run directly (e.g. `python setupEM.py`)
+# rather than imported as part of the setupEM package, so relative import fails.
+if __package__ in (None, ""):
+    from setup_common import (
+        EDIT_STYLE_OPTIONAL, EDIT_STYLE_REQUIRED, COMBO_STYLE_REQUIRED, COMBO_STYLE_OPTIONAL,
+        FileDropLineEdit, FileInputTab, PythonHighlighter, CodeEditor,
+        VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
+    )
+else:
+    from .setup_common import (
+        EDIT_STYLE_OPTIONAL, EDIT_STYLE_REQUIRED, COMBO_STYLE_REQUIRED, COMBO_STYLE_OPTIONAL,
+        FileDropLineEdit, FileInputTab, PythonHighlighter, CodeEditor,
+        VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
+    )
 
 
 '''

--- a/src/setupEM/setupThermal.py
+++ b/src/setupEM/setupThermal.py
@@ -38,11 +38,20 @@ from PySide6.QtCore import Qt, QRegularExpression, QProcess, QRect, QStandardPat
 from gds2palace import *
 
 # shared building blocks used by both setupEM.py and setupThermal.py
-from .setup_common import (
-    EDIT_STYLE_OPTIONAL, EDIT_STYLE_REQUIRED, COMBO_STYLE_REQUIRED, COMBO_STYLE_OPTIONAL,
-    FileDropLineEdit, FileInputTab, PythonHighlighter, CodeEditor,
-    VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
-)
+# __package__ is None/"" when this file is run directly (e.g. `python setupThermal.py`)
+# rather than imported as part of the setupEM package, so relative import fails.
+if __package__ in (None, ""):
+    from setup_common import (
+        EDIT_STYLE_OPTIONAL, EDIT_STYLE_REQUIRED, COMBO_STYLE_REQUIRED, COMBO_STYLE_OPTIONAL,
+        FileDropLineEdit, FileInputTab, PythonHighlighter, CodeEditor,
+        VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
+    )
+else:
+    from .setup_common import (
+        EDIT_STYLE_OPTIONAL, EDIT_STYLE_REQUIRED, COMBO_STYLE_REQUIRED, COMBO_STYLE_OPTIONAL,
+        FileDropLineEdit, FileInputTab, PythonHighlighter, CodeEditor,
+        VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
+    )
 
 
 '''

--- a/src/setupEM/setup_common.py
+++ b/src/setupEM/setup_common.py
@@ -1499,8 +1499,13 @@ class MainWindowBase(QMainWindow):
             return
 
         # local import: stackup_editor.py imports from this module, so importing
-        # it at module load time here would be circular
-        from .stackup_editor import StackupEditorWindow
+        # it at module load time here would be circular.
+        # __package__ is None/"" when this module was itself loaded outside the
+        # setupEM package (e.g. setupEM.py run directly), so relative import fails.
+        if __package__ in (None, ""):
+            from stackup_editor import StackupEditorWindow
+        else:
+            from .stackup_editor import StackupEditorWindow
 
         if getattr(self, "stackup_editor_window", None) is not None:
             self.stackup_editor_window.raise_()

--- a/src/setupEM/stackup_editor.py
+++ b/src/setupEM/stackup_editor.py
@@ -46,7 +46,13 @@ from PySide6.QtGui import QColor, QFontMetrics, QKeySequence, QAction
 from PySide6.QtCore import Qt, QTimer, Signal
 
 from gds2palace import stackup_reader, stackup_writer
-from .setup_common import VectorWidget
+
+# __package__ is None/"" when this file is run directly rather than imported
+# as part of the setupEM package, so relative import fails.
+if __package__ in (None, ""):
+    from setup_common import VectorWidget
+else:
+    from .setup_common import VectorWidget
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
Allow running setupEM.py and setupThermal.py directly, even when not installed as a module. This fixes ´ImportError: attempted relative import with no known parent package´