### PR TITLE
Add ADS Momentum stackup import with derived-mask layer support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "setupEM"
-version = "0.3.5"
+version = "0.3.9"
 description = "Python tool for configuration of gds2palace workflow with GUI."
 readme = "README.md"
 authors = [
     { name = "Volker Muehlhaus", email = "volker@muehlhaus.com" }
 ]
 dependencies = [
-    "gds2palace>=0.3.3",
+    "gds2palace>=0.3.4",
     "PySide6",
     "scipy",
     "requests",

--- a/src/setupEM/momentum_import.py
+++ b/src/setupEM/momentum_import.py
@@ -1,0 +1,780 @@
+"""
+Import ADS Momentum stackup exports (*.subst + materials.matdb, and *.ltd) into a
+stackup XML tree, using the same stackup_writer API the Stackup Editor's other
+mutations go through - so an imported stackup is a normal, editable, validated tree
+like any loaded/hand-built one.
+
+This is a general-purpose importer: it processes every material/dielectric/layer/via
+in the source file uniformly. It carries no process- or vendor-specific assumptions
+(no hardcoded layer names, colors, or skip lists) - unlike the older, IHP-SG13G2-specific
+momentum_to_xml.py script this replaces the GUI-facing need for.
+
+Both formats describe a physical stack from an open-ended top boundary (Momentum
+models this as an unbounded half-space, not a finite material) down to a substrate,
+sometimes terminated by a backside ground plane. The target schema needs a finite
+top thickness to bound the simulation domain, so air_thickness_um is a required
+parameter (the caller is expected to prompt for it) rather than silently guessed. A
+backside ground plane (*.subst's <interface groundplane="1">, *.ltd's BOTTOM COVERED)
+is modeled as a synthetic Dielectric slab at the very bottom of the stack (see
+_GROUND_PLANE_THICKNESS_UM/_GROUND_PLANE_CONDUCTIVITY below) - a Dielectric rather
+than a Layer, deliberately: a Layer only produces geometry where a matching GDSII
+polygon exists on its layer number, which a full-wafer backside ground plane has no
+reason to have in an arbitrary layout, whereas a Dielectric automatically covers the
+whole simulation domain, the same way AIR/Substrate/EPI already do.
+"""
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+
+# __package__ is None/"" when this module was loaded outside the setupEM package
+# (e.g. setupEM.py run directly), so relative import fails - same dual-mode pattern
+# used throughout setupEM.py/setup_common.py/stackup_editor.py for sibling imports.
+if __package__ in (None, ""):
+  import stackup_writer
+else:
+  from . import stackup_writer
+
+_UNIT_TO_MICRON = {
+    "meter": 1e6,
+    "millimeter": 1e3,
+    "micron": 1.0,
+    "nanometer": 1e-3,
+    "mil": 25.4,
+    "inch": 25.4e3,
+}
+
+_EPSILON_UM = 1e-4
+
+# a backside ground plane has no physical thickness in the source data - modeled as a thin,
+# very-high-conductivity Dielectric slab at the bottom of the stack, standing in for a PEC
+# boundary condition
+_GROUND_PLANE_NAME = "BACKSIDEGND"
+_GROUND_PLANE_THICKNESS_UM = 5.0
+_GROUND_PLANE_CONDUCTIVITY = 1e10
+
+
+# -------------------- shared intermediate representation --------------------
+
+@dataclass
+class MaterialSpec:
+  name: str
+  kind: str  # "conductor", "dielectric", "semiconductor", "sheet_resistor"
+  permittivity: float = 1.0
+  loss_tangent: float = 0.0
+  conductivity: float = 0.0
+  rs: float = 0.0  # sheet resistance in Ohm/square, only meaningful for kind="sheet_resistor"
+  color: str = ""  # hex RGB, no '#'
+
+
+@dataclass
+class DielectricSlab:
+  material_name: str
+  thickness_um: float
+
+
+@dataclass
+class LayerEntry:
+  name: str
+  material_name: str
+  kind: str  # "metal" or "via"
+  gds_layer: str
+  zmin: float
+  zmax: float
+
+
+@dataclass
+class ImportResult:
+  tree: ET.ElementTree
+  warnings: list = field(default_factory=list)
+
+
+# -------------------- shared helpers --------------------
+
+def _ground_plane_slab(materials, warnings):
+  """Registers the backside-ground-plane Material (if not already present) and returns
+     a DielectricSlab for it - see module docstring. Callers insert this at position 0
+     of their bottom-to-top slabs list (the very bottom of the stack) once it's otherwise
+     complete, and must also account for its thickness when computing metal/via z (both
+     parsers do this by starting their z-accumulation at _GROUND_PLANE_THICKNESS_UM
+     instead of 0 when a ground plane was detected, rather than shifting positions in an
+     already-built list).
+  """
+  materials.setdefault(_GROUND_PLANE_NAME, MaterialSpec(
+      name=_GROUND_PLANE_NAME, kind="conductor", conductivity=_GROUND_PLANE_CONDUCTIVITY))
+  warnings.append(
+      f"Backside ground plane detected - modeled as a {_GROUND_PLANE_THICKNESS_UM:g}um "
+      f"Dielectric '{_GROUND_PLANE_NAME}' (Material Conductivity={_GROUND_PLANE_CONDUCTIVITY:g}) "
+      f"at the bottom of the stack; adjust thickness/material as needed.")
+  return DielectricSlab(_GROUND_PLANE_NAME, _GROUND_PLANE_THICKNESS_UM)
+
+
+# a shared naming-convention suffix is stripped once it's common to MORE than this many
+# names - not required to be universal, since a handful of materials (e.g. the bulk
+# semiconductor materials) often sit outside a fab's per-technology metal/via naming
+# convention even when most of the file's names follow it (see SG25H5EPIC_Cu_50Ohmcm.ltd:
+# 26 of 28 materials end in "_SG25H5Cu", but EPI_H5/Substrate_H5_50R don't)
+_SUFFIX_STRIP_MIN_COUNT = 4
+
+
+def _find_majority_suffix(names, min_count):
+  """Suffix shared by more than min_count of the given names - not necessarily all of
+     them, and not an arbitrary character-count match: candidates are constrained to
+     start right after a '_' (Momentum's own name-segment delimiter, consistently used
+     across every sample seen), so a short trailing digit that's part of a *different*
+     name's own token (e.g. "Metal2"'s "2", "SiO2"'s "2") can never be mistaken for the
+     start of the real shared suffix - only "_SG25H5Cu" is a candidate for
+     "Metal2_SG25H5Cu", never "2_SG25H5Cu". Ties on count prefer the longer (more
+     specific) suffix. Returns "" if nothing clears min_count.
+  """
+  counts = {}
+  for name in names:
+    start = 0
+    while True:
+      idx = name.find("_", start)
+      if idx == -1:
+        break
+      suffix = name[idx:]
+      if len(suffix) < len(name):  # never propose the whole name as its own suffix
+        counts[suffix] = counts.get(suffix, 0) + 1
+      start = idx + 1
+  if not counts:
+    return ""
+  best_suffix, best_count = max(counts.items(), key=lambda kv: (kv[1], len(kv[0])))
+  return best_suffix if best_count > min_count else ""
+
+
+def _strip_common_material_suffix(materials, slabs, layers, warnings):
+  """If a suffix is shared by more than _SUFFIX_STRIP_MIN_COUNT of the file's material,
+     Layer, and Dielectric names combined, strips it from every name (in any of those
+     three) that has it - not requiring universal agreement, so a handful of names
+     outside the convention (see _SUFFIX_STRIP_MIN_COUNT) don't block cleanup of the
+     rest. Layer/Dielectric names are stripped unconditionally once found (validate_
+     stackup()'s existing name-uniqueness enforcement is relied on further downstream -
+     see _dedup_names() - to resolve any collision this creates); Material renames are
+     more conservative, since materials have no such dedup safety net, so the whole
+     operation is abandoned if it would empty out or collide a Material name.
+
+     _GROUND_PLANE_NAME and "AIR" are always excluded, whether they came from the source
+     file or were defaulted by this importer: both are boundary/placeholder materials,
+     not part of the actual process - Momentum exports name them "AIR"/leave the
+     backside plane unnamed even when every real process material carries a shared
+     per-technology suffix (confirmed against a real sample file).
+  """
+  candidate_names = set(materials) - {_GROUND_PLANE_NAME, "AIR"}
+  candidate_names |= {l.name for l in layers}
+  candidate_names |= {s.material_name for s in slabs}
+
+  suffix = _find_majority_suffix(candidate_names, _SUFFIX_STRIP_MIN_COUNT)
+  if not suffix:
+    return
+
+  def strip(name):
+    return name[:-len(suffix)] if len(name) > len(suffix) and name.endswith(suffix) else name
+
+  material_renames = {name: strip(name) for name in materials
+                       if name not in (_GROUND_PLANE_NAME, "AIR") and strip(name) != name}
+  if not material_renames:
+    return
+
+  final_names = [material_renames.get(name, name) for name in materials]
+  if any(not name for name in final_names) or len(set(final_names)) != len(final_names):
+    return  # would empty out or collide a Material name - abandon entirely
+
+  for old_name, new_name in material_renames.items():
+    spec = materials.pop(old_name)
+    spec.name = new_name
+    materials[new_name] = spec
+
+  for slab in slabs:
+    if slab.material_name in material_renames:
+      slab.material_name = material_renames[slab.material_name]
+
+  for layer in layers:
+    layer.name = strip(layer.name)
+    if layer.material_name in material_renames:
+      layer.material_name = material_renames[layer.material_name]
+
+  warnings.append(
+      f"Stripped common name suffix '{suffix}' (shared by more than "
+      f"{_SUFFIX_STRIP_MIN_COUNT} material/layer/dielectric names)")
+
+
+def _dedup_names(names):
+  """Appends _1, _2, ... to any repeated name, first occurrence unchanged - guarantees
+     the uniqueness validate_stackup() requires for Dielectric/Layer names, regardless
+     of what the source format handed us.
+  """
+  seen = {}
+  result = []
+  for name in names:
+    if name not in seen:
+      seen[name] = 0
+      result.append(name)
+    else:
+      seen[name] += 1
+      result.append(f"{name}_{seen[name]}")
+  return result
+
+
+def _same_dielectric_material(name_a, name_b, materials):
+  a = materials.get(name_a)
+  b = materials.get(name_b)
+  if a is None or b is None:
+    return name_a == name_b
+  return (a.kind == b.kind
+          and abs(a.permittivity - b.permittivity) < 1e-9
+          and abs(a.loss_tangent - b.loss_tangent) < 1e-9
+          and abs(a.conductivity - b.conductivity) < 1e-9)
+
+
+def _add_material_element(root, spec):
+  type_map = {"conductor": "Conductor", "dielectric": "Dielectric",
+              "semiconductor": "Semiconductor", "sheet_resistor": "Resistor"}
+  attrs = {"Name": spec.name, "Type": type_map[spec.kind]}
+  if spec.kind == "sheet_resistor":
+    attrs["Rs"] = f"{spec.rs:.6g}"
+  else:
+    attrs["Permittivity"] = f"{spec.permittivity:.6g}"
+    attrs["DielectricLossTangent"] = f"{spec.loss_tangent:.6g}"
+    attrs["Conductivity"] = f"{spec.conductivity:.6g}"
+  if spec.color:
+    attrs["Color"] = spec.color
+  stackup_writer.add_material(root, **attrs)
+
+
+def _build_tree(slabs, layers, materials, warnings):
+  """The core shared by both formats: everything downstream of "a bottom-to-top list of
+     dielectric slabs, all with real positive thickness (including an already-sized top
+     AIR slab), plus a list of metal/via Layer entries with absolute Zmin/Zmax already
+     resolved in that same bottom-up z=0-at-the-very-bottom frame".
+  Args:
+      slabs (list of DielectricSlab): bottom-to-top
+      layers (list of LayerEntry): zmin/zmax in the same frame as slabs, mutated in place
+      materials (dict): name -> MaterialSpec
+      warnings (list of str): appended to in place
+  Returns:
+      xml.etree.ElementTree.ElementTree
+  """
+  # via nudge: a via's raw zmin, as resolved from the source format's own indexing/
+  # interface scheme, naturally lands at the BOTTOM of the metal it connects to below
+  # (both source formats define it that way) rather than that metal's TOP, where it
+  # actually needs to start - shift any via whose zmin coincides with a metal's zmin
+  # up by that metal's own thickness.
+  metal_spans = [(l.zmin, l.zmax - l.zmin) for l in layers if l.kind == "metal"]
+  for l in layers:
+    if l.kind != "via":
+      continue
+    for metal_zmin, metal_thickness in metal_spans:
+      if abs(l.zmin - metal_zmin) < _EPSILON_UM:
+        l.zmin += metal_thickness
+        break
+
+  # merge adjacent dielectric slabs sharing the same material properties - this only
+  # changes how the <Dielectrics> section is presented (fewer, combined-thickness
+  # entries); it cannot change any Layer's already-resolved absolute z, since summed
+  # thickness across a merged run is identical to the sum of its unmerged parts.
+  merged = []
+  for slab in slabs:
+    if merged and _same_dielectric_material(merged[-1].material_name, slab.material_name, materials):
+      merged[-1] = DielectricSlab(merged[-1].material_name, merged[-1].thickness_um + slab.thickness_um)
+    else:
+      merged.append(DielectricSlab(slab.material_name, slab.thickness_um))
+
+  # re-baseline: both source formats have z=0 at the very bottom of the stack; the
+  # target schema's convention (matching every hand-curated reference file) is z=0 at
+  # the top of the substrate/semiconductor region, with a <Substrate Offset="..."> that
+  # shifts the drawn Layer stack up to meet it - so offset = z at the top of the
+  # topmost semiconductor slab, walked pre-merge (merging never changes this value).
+  offset = 0.0
+  z = 0.0
+  for slab in slabs:
+    zmax = z + slab.thickness_um
+    material = materials.get(slab.material_name)
+    if material is not None and material.kind == "semiconductor":
+      offset = zmax
+    z = zmax
+
+  for l in layers:
+    l.zmin -= offset
+    l.zmax -= offset
+
+  dielectric_names = _dedup_names([s.material_name for s in merged])
+  layer_names = _dedup_names([l.name for l in layers])
+
+  tree = stackup_writer.new_stackup_tree()
+  root = tree.getroot()
+
+  used_material_names = {s.material_name for s in merged} | {l.material_name for l in layers}
+  for name in sorted(used_material_names):
+    spec = materials.get(name)
+    if spec is None:
+      warnings.append(f"Material '{name}' is used but was never defined - substituted with AIR-like defaults")
+      spec = MaterialSpec(name=name, kind="dielectric", permittivity=1.0)
+    _add_material_element(root, spec)
+
+  # <Dielectrics> must read top-to-bottom; slabs/merged were built bottom-to-top
+  for name, slab in reversed(list(zip(dielectric_names, merged))):
+    stackup_writer.add_dielectric(root, Name=name, Material=slab.material_name,
+                                   Thickness=f"{slab.thickness_um:.4f}")
+
+  if offset:
+    stackup_writer.set_substrate_offset(root, f"{offset:.4f}")
+
+  for name, l in zip(layer_names, layers):
+    material = materials.get(l.material_name)
+    is_sheet = material is not None and material.kind == "sheet_resistor"
+    zmin = l.zmin
+    zmax = zmin if is_sheet else l.zmax
+    layer_type = "sheet" if is_sheet else ("via" if l.kind == "via" else "conductor")
+    stackup_writer.add_layer(root, Name=name, Type=layer_type, Material=l.material_name,
+                              Zmin=f"{zmin:.4f}", Zmax=f"{zmax:.4f}", Layer=l.gds_layer)
+
+  errors = stackup_writer.validate_stackup(root)
+  if errors:
+    raise ValueError("Imported stackup failed validation:\n" + "\n".join(f"- {e}" for e in errors))
+
+  return tree
+
+
+# -------------------- materials.matdb (*.subst companion) --------------------
+
+def _parse_matdb(matdb_path):
+  materials = {}
+  warnings = []
+  root = ET.parse(matdb_path).getroot()
+
+  for el in root.iter("Conductor"):
+    name = el.get("name")
+    real = el.get("real") or ""
+    parts = real.split()
+    try:
+      value = float(parts[0]) if parts else 0.0
+    except ValueError:
+      value = 0.0
+      warnings.append(f"Conductor '{name}': could not parse conductivity value '{real}', using 0")
+    if "Ohm/Sq" in real:
+      materials[name] = MaterialSpec(name=name, kind="sheet_resistor", rs=value)
+    else:
+      if "Siemens/m" not in real:
+        warnings.append(f"Conductor '{name}': unrecognized conductivity unit in '{real}', assuming Siemens/m")
+      materials[name] = MaterialSpec(name=name, kind="conductor", conductivity=value)
+
+  for el in root.iter("Dielectric"):
+    name = el.get("name")
+    er = el.get("er_real")
+    tand = el.get("er_loss")
+    materials[name] = MaterialSpec(
+        name=name, kind="dielectric",
+        permittivity=float(er) if er not in (None, "") else 1.0,
+        loss_tangent=float(tand) if tand not in (None, "") else 0.0)
+
+  for el in root.iter("Semiconductor"):
+    name = el.get("name")
+    er = el.get("er_real")
+    resistivity = el.get("resistivity") or ""
+    try:
+      resistivity_value = float(resistivity.split()[0]) if resistivity else None
+    except (ValueError, IndexError):
+      resistivity_value = None
+      warnings.append(f"Semiconductor '{name}': could not parse resistivity '{resistivity}', using 0 S/m")
+    conductivity = (1.0 / (resistivity_value * 0.01)) if resistivity_value else 0.0
+    materials[name] = MaterialSpec(
+        name=name, kind="semiconductor",
+        permittivity=float(er) if er not in (None, "") else 1.0,
+        conductivity=conductivity)
+
+  materials.setdefault("AIR", MaterialSpec(name="AIR", kind="dielectric", permittivity=1.0))
+
+  return materials, warnings
+
+
+# -------------------- *.subst --------------------
+
+def _thickness_um(value_str, unit_str, warnings, context):
+  if unit_str and unit_str not in _UNIT_TO_MICRON:
+    warnings.append(f"{context}: unrecognized unit '{unit_str}', assuming micron")
+  factor = _UNIT_TO_MICRON.get(unit_str, 1.0)
+  if value_str in (None, ""):
+    return 0.0
+  return float(value_str) * factor
+
+
+def _parse_subst(subst_path, materials, air_thickness_um, warnings):
+  root = ET.parse(subst_path).getroot()
+
+  slab_materials = []
+  slab_thickness = []
+  for el in root.iter("material"):
+    name = el.get("materialname")
+    if name not in materials:
+      warnings.append(f"Dielectric slab material '{name}' not found in materials.matdb, skipped")
+      continue
+    thickness = _thickness_um(el.get("thick"), el.get("thickunit"), warnings, f"Dielectric slab '{name}'")
+    slab_materials.append(name)
+    slab_thickness.append(thickness)
+
+  groundplane_detected = any(el.get("groundplane") == "1" for el in root.iter("interface"))
+
+  substrates_el = root.find("substrates")
+  if substrates_el is not None and len(substrates_el) > 0:
+    warnings.append("<substrates> section is non-empty and was not imported (unsupported).")
+
+  if not slab_thickness:
+    raise ValueError("No usable dielectric slabs found in *.subst file")
+
+  # the topmost (last, file-order) slab with ~zero declared thickness is Momentum's
+  # open/unbounded top boundary - give it the prompted thickness. If the file doesn't
+  # have one (unusual, but not impossible), append a fresh AIR slab on top instead.
+  if slab_thickness[-1] < _EPSILON_UM:
+    slab_thickness[-1] = air_thickness_um
+  else:
+    materials.setdefault("AIR", MaterialSpec(name="AIR", kind="dielectric", permittivity=1.0))
+    slab_materials.append("AIR")
+    slab_thickness.append(air_thickness_um)
+
+  # expand="1": a metal that doesn't fit inside its normally-enclosing slab grows that
+  # slab's thickness to fit it - must happen before interface positions are computed
+  for el in root.iter("layer"):
+    try:
+      index = int(el.get("index"))
+    except (TypeError, ValueError):
+      continue
+    thickness = _thickness_um(el.get("thick"), el.get("thickunit"), warnings,
+                               f"Layer '{el.get('materialname')}'")
+    if el.get("expand") == "1":
+      target_index = index + 1 if thickness > 0 else index
+      if 0 <= target_index < len(slab_thickness):
+        slab_thickness[target_index] += abs(thickness)
+
+  # interface_pos[i] = cumulative z at the TOP of slab i (after its own thickness is
+  # added) - this is where a <layer index="i">/<via index1="i"> attaches. A <layer
+  # index="i"> physically sits right above dielectric slab i (e.g. index="2" - EPI in
+  # the sample stack - is where Activ, the first metal above EPI, attaches). A detected
+  # ground plane sits below slab index 0 without being part of the file's own index
+  # numbering (inserted into the *output* slabs list separately, below) - starting the
+  # accumulation at its thickness instead of 0 shifts every index-based z by the same
+  # amount this slab_thickness list is silently missing it, without disturbing any
+  # <layer index="N">/<via index1="N"> value, which refer to *this* array's positions.
+  interface_pos = []
+  z = _GROUND_PLANE_THICKNESS_UM if groundplane_detected else 0.0
+  for t in slab_thickness:
+    z += t
+    interface_pos.append(z)
+
+  layers = []
+  for el in root.iter("layer"):
+    name = el.get("materialname")
+    if name not in materials:
+      warnings.append(f"Layer material '{name}' not found in materials.matdb, skipped")
+      continue
+    try:
+      index = int(el.get("index"))
+    except (TypeError, ValueError):
+      warnings.append(f"Layer '{name}': missing/invalid index, skipped")
+      continue
+    thickness = _thickness_um(el.get("thick"), el.get("thickunit"), warnings, f"Layer '{name}'")
+    # a negative thick means this metal grows DOWN from its interface (into the slab
+    # below, index N) instead of UP (into the slab above, index N+1) - same convention
+    # "expand"'s target-slab choice already relies on, just for a plain slab's position
+    # rather than which one to grow (see the target_index branch above). Either way the
+    # interface itself is one edge of the metal, never its Zmin specifically - min/max
+    # the two candidate z's rather than assuming the sign, so Zmax is always > Zmin
+    # regardless of growth direction.
+    interface_z = interface_pos[index]
+    other_z = interface_z + thickness
+    zmin, zmax = min(interface_z, other_z), max(interface_z, other_z)
+    gds_layer = el.get("layer")
+    layers.append(LayerEntry(name=name, material_name=name, kind="metal",
+                              gds_layer=gds_layer, zmin=zmin, zmax=zmax))
+    # sheet="1" is a Momentum solver hint ("treat as electrically thin"), not a
+    # geometric zero-thickness declaration - this layer keeps its real thickness above.
+
+  for el in root.iter("via"):
+    name = el.get("materialname")
+    if name not in materials:
+      warnings.append(f"Via material '{name}' not found in materials.matdb, skipped")
+      continue
+    try:
+      index1 = int(el.get("index1"))
+      index2 = int(el.get("index2"))
+    except (TypeError, ValueError):
+      warnings.append(f"Via '{name}': missing/invalid index1/index2, skipped")
+      continue
+    gds_layer = el.get("layer")
+    layers.append(LayerEntry(name=name, material_name=name, kind="via", gds_layer=gds_layer,
+                              zmin=interface_pos[index1], zmax=interface_pos[index2]))
+
+  slabs = [DielectricSlab(m, t) for m, t in zip(slab_materials, slab_thickness) if t > _EPSILON_UM]
+  if groundplane_detected:
+    slabs.insert(0, _ground_plane_slab(materials, warnings))
+
+  return slabs, layers
+
+
+def import_subst(subst_path, matdb_path, air_thickness_um):
+  """Import an ADS Momentum *.subst + materials.matdb pair into a stackup tree.
+  Args:
+      subst_path (string): path to the *.subst file
+      matdb_path (string): path to the companion materials.matdb file
+      air_thickness_um (float): thickness to use for the open-boundary AIR region
+        above the stack (the source file leaves this undefined)
+  Returns:
+      ImportResult
+  """
+  materials, warnings = _parse_matdb(matdb_path)
+  slabs, layers = _parse_subst(subst_path, materials, air_thickness_um, warnings)
+  _strip_common_material_suffix(materials, slabs, layers, warnings)
+  tree = _build_tree(slabs, layers, materials, warnings)
+  return ImportResult(tree=tree, warnings=warnings)
+
+
+# -------------------- *.ltd --------------------
+
+_KV_RE = re.compile(r'(\w+)=("[^"]*"|\S+)')
+
+
+def _ltd_kv(line):
+  return {key: value.strip('"') for key, value in _KV_RE.findall(line)}
+
+
+def _split_ltd_sections(text):
+  sections = {}
+  current = None
+  buf = []
+  for raw_line in text.splitlines():
+    line = raw_line.strip()
+    if not line:
+      continue
+    m = re.match(r'^BEGIN_(\w+)$', line)
+    if m:
+      current = m.group(1)
+      buf = []
+      continue
+    m = re.match(r'^END_(\w+)$', line)
+    if m:
+      sections[current] = buf
+      current = None
+      continue
+    if current:
+      buf.append(line)
+  return sections
+
+
+def _parse_ltd(ltd_path, air_thickness_um, warnings):
+  with open(ltd_path, encoding="utf-8") as f:
+    text = f.read()
+  sections = _split_ltd_sections(text)
+
+  for line in sections.get("UNITS", []):
+    if line.startswith("DISTANCE=") and line.split("=", 1)[1].strip().upper() != "METRE":
+      warnings.append(f"*.ltd declares {line} - this importer assumes METRE, lengths may be wrong")
+    if line.startswith("RESISTIVITY=") and line.split("=", 1)[1].strip().upper() != "OHM.CM":
+      warnings.append(f"*.ltd declares {line} - this importer assumes OHM.CM, semiconductor conductivity may be wrong")
+
+  materials = {}
+  for line in sections.get("MATERIAL", []):
+    tokens = line.split()
+    if len(tokens) < 2:
+      continue
+    name = tokens[1]
+    kv = _ltd_kv(line)
+    conductivity = kv.get("CONDUCTIVITY")
+    resistance = kv.get("RESISTANCE")
+    permittivity = kv.get("PERMITTIVITY")
+    resistivity = kv.get("RESISTIVITY")
+    loss_tangent = kv.get("LOSSTANGENT")
+    if resistance is not None:
+      materials[name] = MaterialSpec(name=name, kind="sheet_resistor", rs=float(resistance))
+    elif conductivity is not None:
+      materials[name] = MaterialSpec(name=name, kind="conductor", conductivity=float(conductivity))
+    elif permittivity is not None and resistivity is not None:
+      materials[name] = MaterialSpec(name=name, kind="semiconductor",
+                                      permittivity=float(permittivity),
+                                      conductivity=1.0 / (float(resistivity) * 0.01))
+    elif permittivity is not None:
+      materials[name] = MaterialSpec(name=name, kind="dielectric",
+                                      permittivity=float(permittivity),
+                                      loss_tangent=float(loss_tangent) if loss_tangent is not None else 0.0)
+    else:
+      warnings.append(f"Material '{name}': could not classify from '{line}', skipped")
+  materials.setdefault("AIR", MaterialSpec(name="AIR", kind="dielectric", permittivity=1.0))
+
+  operations = {}
+  for line in sections.get("OPERATION", []):
+    tokens = line.split()
+    if len(tokens) < 2:
+      continue
+    name = tokens[1]
+    kv = _ltd_kv(line)
+    if "DRILL" in tokens:
+      operations[name] = ("via", None)
+    elif "INTRUDE" in kv:
+      operations[name] = ("metal", float(kv["INTRUDE"]) * 1e6)  # meters -> micron
+    elif "SHEET" in tokens:
+      operations[name] = ("sheet", None)
+    else:
+      warnings.append(f"Operation '{name}': could not classify from '{line}'")
+
+  masks = {}
+  for line in sections.get("MASK", []):
+    tokens = line.split()
+    if len(tokens) < 2:
+      continue
+    gds_layer = tokens[1]
+    kv = _ltd_kv(line)
+    name = kv.get("Name")
+    if name is None:
+      continue
+    masks[name] = {
+        "gds_layer": gds_layer,
+        "material": kv.get("MATERIAL"),
+        "operation": kv.get("OPERATION"),
+        "color": kv.get("COLOR", ""),
+    }
+
+  stack_lines = sections.get("STACK", [])
+  slabs = []
+  # accumulated by mask name rather than appended directly to `layers`: the same via
+  # (or, in principle, metal) mask can be attached to more than one LAYER/INTERFACE
+  # line - e.g. a via passing through two adjacent dielectric segments with a
+  # different metal's INTERFACE sandwiched in between (TopVia1 in the sample stack,
+  # spanning both the SubstrateLayer8/equivalent_for_MIM and SubstrateLayer9/SiO2
+  # segments around the MIM plate) - such occurrences must union into one Layer
+  # spanning from the lowest zmin to the highest zmax seen, not become separate
+  # same-named entries.
+  spans = {}  # mask name -> [material_name, kind, gds_layer, zmin, zmax]
+  z = 0.0
+  groundplane_detected = False
+
+  for line in reversed(stack_lines):
+    tokens = line.split()
+    if not tokens:
+      continue
+    keyword = tokens[0]
+    kv = _ltd_kv(line)
+
+    if keyword == "BOTTOM":
+      state = tokens[1].upper() if len(tokens) > 1 else ""
+      if state == "COVERED":
+        # BOTTOM is always the first line seen here (it's the last line in the file,
+        # and this loop walks in reverse) - z is still untouched at 0.0, so starting
+        # it at the ground plane's thickness instead shifts every subsequent slab/
+        # metal/via z by the same amount the plane itself will occupy below them
+        groundplane_detected = True
+        z = _GROUND_PLANE_THICKNESS_UM
+      continue
+
+    if keyword == "TOP":
+      state = tokens[1].upper() if len(tokens) > 1 else ""
+      top_material = kv.get("MATERIAL", "AIR")
+      if state == "OPEN":
+        materials.setdefault(top_material, MaterialSpec(name=top_material, kind="dielectric", permittivity=1.0))
+        slabs.append(DielectricSlab(top_material, air_thickness_um))
+      elif state == "COVERED":
+        warnings.append(
+            "Top boundary (TOP COVERED) detected - has no GDSII layer number and was not "
+            "modeled; add manually if needed.")
+      continue
+
+    if keyword == "LAYER":
+      material_name = kv.get("MATERIAL")
+      height_m = kv.get("HEIGHT")
+      if material_name not in materials:
+        warnings.append(f"Dielectric slab material '{material_name}' not found, skipped")
+        continue
+      thickness_um = float(height_m) * 1e6 if height_m else 0.0
+      zmin = z
+      z += thickness_um
+      slabs.append(DielectricSlab(material_name, thickness_um))
+
+      mask_match = re.search(r'MASK=\{([^}]*)\}', line)
+      if mask_match:
+        for via_mask_name in mask_match.group(1).split():
+          mask = masks.get(via_mask_name)
+          if mask is None:
+            warnings.append(f"Mask '{via_mask_name}' referenced in stack but not defined in BEGIN_MASK, skipped")
+            continue
+          op = operations.get(mask["operation"])
+          if op is None or op[0] != "via":
+            warnings.append(f"Mask '{via_mask_name}' is attached to a dielectric LAYER line but its "
+                             f"operation isn't DRILL - expected a via, skipped")
+            continue
+          mat_name = mask["material"]
+          if mat_name not in materials:
+            warnings.append(f"Via material '{mat_name}' not found, skipped")
+            continue
+          existing = spans.get(via_mask_name)
+          if existing is None:
+            spans[via_mask_name] = [mat_name, "via", mask["gds_layer"], zmin, z]
+          else:
+            existing[3] = min(existing[3], zmin)
+            existing[4] = max(existing[4], z)
+      continue
+
+    if keyword == "INTERFACE":
+      mask_match = re.search(r'MASK=\{([^}]*)\}', line)
+      if not mask_match:
+        continue
+      for metal_mask_name in mask_match.group(1).split():
+        mask = masks.get(metal_mask_name)
+        if mask is None:
+          warnings.append(f"Mask '{metal_mask_name}' referenced in stack but not defined in BEGIN_MASK, skipped")
+          continue
+        op = operations.get(mask["operation"])
+        if op is None or op[0] == "via":
+          warnings.append(f"Mask '{metal_mask_name}' is attached to an INTERFACE line but its "
+                           f"operation is DRILL - expected a metal, skipped")
+          continue
+        if op[0] == "sheet":
+          warnings.append(f"Mask '{metal_mask_name}' uses a SHEET operation with no thickness "
+                           f"defined - skipped, add manually if needed")
+          continue
+        mat_name = mask["material"]
+        if mat_name not in materials:
+          warnings.append(f"Layer material '{mat_name}' not found, skipped")
+          continue
+        if mask["color"]:
+          materials[mat_name].color = mask["color"]
+        thickness_um = op[1]
+        existing = spans.get(metal_mask_name)
+        # INTRUDE is documented/observed as always positive in *.ltd (unlike *.subst's
+        # thick, which can be negative to mean "grows down") - min/max anyway, cheaply
+        # future-proofing this the same way _parse_subst's metal loop must for real.
+        metal_zmin, metal_zmax = min(z, z + thickness_um), max(z, z + thickness_um)
+        if existing is None:
+          spans[metal_mask_name] = [mat_name, "metal", mask["gds_layer"], metal_zmin, metal_zmax]
+        else:
+          existing[3] = min(existing[3], metal_zmin)
+          existing[4] = max(existing[4], metal_zmax)
+      continue
+
+  if not slabs:
+    raise ValueError("No usable dielectric slabs found in *.ltd file")
+
+  layers = [LayerEntry(name=name, material_name=mat_name, kind=kind, gds_layer=gds_layer, zmin=zmin, zmax=zmax)
+            for name, (mat_name, kind, gds_layer, zmin, zmax) in spans.items()]
+
+  # slabs were built while walking the file in reverse (bottom-to-top), matching
+  # _build_tree's expected bottom-to-top input order - the ground plane, if any,
+  # belongs at the very start of that order (the true bottom of the stack)
+  if groundplane_detected:
+    slabs.insert(0, _ground_plane_slab(materials, warnings))
+
+  return slabs, layers, materials
+
+
+def import_ltd(ltd_path, air_thickness_um):
+  """Import an ADS Momentum *.ltd file into a stackup tree.
+  Args:
+      ltd_path (string): path to the *.ltd file
+      air_thickness_um (float): thickness to use for the open-boundary AIR region
+        above the stack (the source file leaves this undefined)
+  Returns:
+      ImportResult
+  """
+  warnings = []
+  slabs, layers, materials = _parse_ltd(ltd_path, air_thickness_um, warnings)
+  _strip_common_material_suffix(materials, slabs, layers, warnings)
+  tree = _build_tree(slabs, layers, materials, warnings)
+  return ImportResult(tree=tree, warnings=warnings)

--- a/src/setupEM/momentum_import.py
+++ b/src/setupEM/momentum_import.py
@@ -84,6 +84,14 @@ class LayerEntry:
 
 
 @dataclass
+class DerivedLayerEntry:
+  name: str
+  target_gds_layer: str
+  operation: str  # "AND", "OR", "XOR", or "NOT"
+  operand_gds_layers: list
+
+
+@dataclass
 class ImportResult:
   tree: ET.ElementTree
   warnings: list = field(default_factory=list)
@@ -144,16 +152,17 @@ def _find_majority_suffix(names, min_count):
   return best_suffix if best_count > min_count else ""
 
 
-def _strip_common_material_suffix(materials, slabs, layers, warnings):
+def _strip_common_material_suffix(materials, slabs, layers, warnings, derived_layers=None):
   """If a suffix is shared by more than _SUFFIX_STRIP_MIN_COUNT of the file's material,
-     Layer, and Dielectric names combined, strips it from every name (in any of those
-     three) that has it - not requiring universal agreement, so a handful of names
-     outside the convention (see _SUFFIX_STRIP_MIN_COUNT) don't block cleanup of the
-     rest. Layer/Dielectric names are stripped unconditionally once found (validate_
-     stackup()'s existing name-uniqueness enforcement is relied on further downstream -
-     see _dedup_names() - to resolve any collision this creates); Material renames are
-     more conservative, since materials have no such dedup safety net, so the whole
-     operation is abandoned if it would empty out or collide a Material name.
+     Layer, Dielectric, and DerivedLayer names combined, strips it from every name (in
+     any of those) that has it - not requiring universal agreement, so a handful of
+     names outside the convention (see _SUFFIX_STRIP_MIN_COUNT) don't block cleanup of
+     the rest. Layer/Dielectric/DerivedLayer names are stripped unconditionally once
+     found (validate_stackup()'s existing name-uniqueness enforcement is relied on
+     further downstream - see _dedup_names() - to resolve any collision this creates);
+     Material renames are more conservative, since materials have no such dedup safety
+     net, so the whole operation is abandoned if it would empty out or collide a
+     Material name.
 
      _GROUND_PLANE_NAME and "AIR" are always excluded, whether they came from the source
      file or were defaulted by this importer: both are boundary/placeholder materials,
@@ -164,6 +173,7 @@ def _strip_common_material_suffix(materials, slabs, layers, warnings):
   candidate_names = set(materials) - {_GROUND_PLANE_NAME, "AIR"}
   candidate_names |= {l.name for l in layers}
   candidate_names |= {s.material_name for s in slabs}
+  candidate_names |= {d.name for d in derived_layers or []}
 
   suffix = _find_majority_suffix(candidate_names, _SUFFIX_STRIP_MIN_COUNT)
   if not suffix:
@@ -194,6 +204,9 @@ def _strip_common_material_suffix(materials, slabs, layers, warnings):
     layer.name = strip(layer.name)
     if layer.material_name in material_renames:
       layer.material_name = material_renames[layer.material_name]
+
+  for derived in derived_layers or []:
+    derived.name = strip(derived.name)
 
   warnings.append(
       f"Stripped common name suffix '{suffix}' (shared by more than "
@@ -243,7 +256,7 @@ def _add_material_element(root, spec):
   stackup_writer.add_material(root, **attrs)
 
 
-def _build_tree(slabs, layers, materials, warnings):
+def _build_tree(slabs, layers, materials, warnings, derived_layers=None):
   """The core shared by both formats: everything downstream of "a bottom-to-top list of
      dielectric slabs, all with real positive thickness (including an already-sized top
      AIR slab), plus a list of metal/via Layer entries with absolute Zmin/Zmax already
@@ -253,6 +266,8 @@ def _build_tree(slabs, layers, materials, warnings):
       layers (list of LayerEntry): zmin/zmax in the same frame as slabs, mutated in place
       materials (dict): name -> MaterialSpec
       warnings (list of str): appended to in place
+      derived_layers (list of DerivedLayerEntry or None): only *.ltd's DERIVEDMASK
+        sections produce these; *.subst has no equivalent concept
   Returns:
       xml.etree.ElementTree.ElementTree
   """
@@ -329,6 +344,12 @@ def _build_tree(slabs, layers, materials, warnings):
     layer_type = "sheet" if is_sheet else ("via" if l.kind == "via" else "conductor")
     stackup_writer.add_layer(root, Name=name, Type=layer_type, Material=l.material_name,
                               Zmin=f"{zmin:.4f}", Zmax=f"{zmax:.4f}", Layer=l.gds_layer)
+
+  derived_names = _dedup_names([d.name for d in derived_layers]) if derived_layers else []
+  for name, derived in zip(derived_names, derived_layers or []):
+    el = stackup_writer.add_derived_layer(root, Name=name, Layer=derived.target_gds_layer,
+                                           Operation=derived.operation)
+    stackup_writer.set_operands(el, derived.operand_gds_layers)
 
   errors = stackup_writer.validate_stackup(root)
   if errors:
@@ -531,11 +552,18 @@ def import_subst(subst_path, matdb_path, air_thickness_um):
 
 # -------------------- *.ltd --------------------
 
-_KV_RE = re.compile(r'(\w+)=("[^"]*"|\S+)')
+_KV_RE = re.compile(r'(\w+)\s*=\s*("[^"]*"|\S+)')
+_MASK_BRACE_RE = re.compile(r'MASK\s*=\s*\{([^}]*)\}')
 
 
 def _ltd_kv(line):
-  return {key: value.strip('"') for key, value in _KV_RE.findall(line)}
+  """Parses "KEY=value" / "KEY = value" / "KEY="quoted value"" tokens from a *.ltd line
+     into a dict keyed by UPPERCASED attribute name. Real exports vary both in whether
+     '=' has surrounding whitespace and in attribute name case (seen "Name="/"NAME=" for
+     the very same attribute in two real files from the same PDK, exported by different
+     ADS versions) - lookups here must be case-insensitive to be reliable.
+  """
+  return {key.upper(): value.strip('"') for key, value in _KV_RE.findall(line)}
 
 
 def _split_ltd_sections(text):
@@ -561,6 +589,19 @@ def _split_ltd_sections(text):
   return sections
 
 
+def _resolve_mask_token(token, masks, masks_by_layer):
+  """A MASK={...} entry's members (in BEGIN_STACK or a DERIVEDMASK definition) can be
+     given as mask Names or as bare GDS layer numbers - both seen in real exports of the
+     same PDK from different ADS versions. Tries a Name match first, falls back to a
+     layer-number match.
+  Returns:
+      dict or None: the resolved mask's own dict from `masks`, or None if neither matches
+  """
+  if token in masks:
+    return masks[token]
+  return masks_by_layer.get(token)
+
+
 def _parse_ltd(ltd_path, air_thickness_um, warnings):
   with open(ltd_path, encoding="utf-8") as f:
     text = f.read()
@@ -573,6 +614,13 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
       warnings.append(f"*.ltd declares {line} - this importer assumes OHM.CM, semiconductor conductivity may be wrong")
 
   materials = {}
+  # RESISTANCE= (Ohm/Sq) can't be classified from the MATERIAL line alone: a real GPDK
+  # export uses it both for genuine zero-thickness sheet resistors AND for ordinary
+  # conductors that still get real 3D thickness via an INTRUDE/EXPAND operation (e.g. a
+  # "Poly" resistor layer vs. a "Metal1" that just happens to express its conductivity as
+  # a sheet-resistance-equivalent instead of CONDUCTIVITY). Deferred to a second pass
+  # below, once every material's actual Layer thickness is known.
+  pending_rs = {}
   for line in sections.get("MATERIAL", []):
     tokens = line.split()
     if len(tokens) < 2:
@@ -585,7 +633,8 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
     resistivity = kv.get("RESISTIVITY")
     loss_tangent = kv.get("LOSSTANGENT")
     if resistance is not None:
-      materials[name] = MaterialSpec(name=name, kind="sheet_resistor", rs=float(resistance))
+      pending_rs[name] = float(resistance)
+      materials[name] = MaterialSpec(name=name, kind="conductor", conductivity=0.0)
     elif conductivity is not None:
       materials[name] = MaterialSpec(name=name, kind="conductor", conductivity=float(conductivity))
     elif permittivity is not None and resistivity is not None:
@@ -609,29 +658,87 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
     kv = _ltd_kv(line)
     if "DRILL" in tokens:
       operations[name] = ("via", None)
-    elif "INTRUDE" in kv:
-      operations[name] = ("metal", float(kv["INTRUDE"]) * 1e6)  # meters -> micron
+    elif "INTRUDE" in kv or "EXPAND" in kv:
+      # both give a thickness in meters; DOWN (vs. the default UP) means this metal
+      # grows downward from its interface into the slab below - same concept *.subst
+      # expresses via a negative thick value, here via an explicit direction token
+      magnitude_um = float(kv.get("INTRUDE") or kv.get("EXPAND")) * 1e6
+      thickness_um = -magnitude_um if "DOWN" in tokens else magnitude_um
+      operations[name] = ("metal", thickness_um)
     elif "SHEET" in tokens:
       operations[name] = ("sheet", None)
+    elif "WALL" in tokens:
+      operations[name] = ("wall", None)
     else:
       warnings.append(f"Operation '{name}': could not classify from '{line}'")
 
   masks = {}
+  masks_by_layer = {}
   for line in sections.get("MASK", []):
     tokens = line.split()
     if len(tokens) < 2:
       continue
     gds_layer = tokens[1]
     kv = _ltd_kv(line)
-    name = kv.get("Name")
+    name = kv.get("NAME")
     if name is None:
       continue
     masks[name] = {
+        "name": name,
         "gds_layer": gds_layer,
         "material": kv.get("MATERIAL"),
         "operation": kv.get("OPERATION"),
         "color": kv.get("COLOR", ""),
+        "derivedmask": kv.get("DERIVEDMASK"),
     }
+    masks_by_layer[gds_layer] = masks[name]
+
+  derived_masks = {}
+  for line in sections.get("DERIVEDMASK", []):
+    tokens = line.split()
+    if len(tokens) < 2:
+      continue
+    name = tokens[1]
+    kv = _ltd_kv(line)
+    operator = kv.get("OPERATOR")
+    mask_match = _MASK_BRACE_RE.search(line)
+    operands = mask_match.group(1).split() if mask_match else []
+    derived_masks[name] = (operator, operands)
+
+  # build <DerivedLayer> entries: one per BEGIN_MASK entry that references a
+  # BEGIN_DERIVEDMASK definition via DERIVEDMASK=... - the mask's own gds_layer is the
+  # DerivedLayer's target Layer number; its DERIVEDMASK's OPERATOR/MASK={...} give the
+  # Operation and Operands (each operand resolved the same Name-or-layer-number way as
+  # any other MASK={...} reference). The mask itself also gets a normal <Layer> entry
+  # further below (it's still placed in BEGIN_STACK like any other via/metal) - nothing
+  # special needed for that here.
+  derived_layers = []
+  for mask_name, mask in masks.items():
+    dm_name = mask["derivedmask"]
+    if not dm_name:
+      continue
+    dm = derived_masks.get(dm_name)
+    if dm is None:
+      warnings.append(f"Mask '{mask_name}' references DERIVEDMASK '{dm_name}' which is not "
+                       f"defined in BEGIN_DERIVEDMASK, skipped")
+      continue
+    operator, operand_tokens = dm
+    if operator not in ("AND", "OR", "XOR", "NOT"):
+      warnings.append(f"DerivedMask '{dm_name}': unsupported OPERATOR '{operator}', skipped")
+      continue
+    operand_layers = []
+    unresolved = False
+    for token in operand_tokens:
+      operand_mask = _resolve_mask_token(token, masks, masks_by_layer)
+      if operand_mask is None:
+        warnings.append(f"DerivedMask '{dm_name}': operand '{token}' matches no mask Name "
+                         f"or GDS layer number, skipped")
+        unresolved = True
+        break
+      operand_layers.append(operand_mask["gds_layer"])
+    if not unresolved:
+      derived_layers.append(DerivedLayerEntry(name=mask_name, target_gds_layer=mask["gds_layer"],
+                                               operation=operator, operand_gds_layers=operand_layers))
 
   stack_lines = sections.get("STACK", [])
   slabs = []
@@ -646,6 +753,7 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
   spans = {}  # mask name -> [material_name, kind, gds_layer, zmin, zmax]
   z = 0.0
   groundplane_detected = False
+  bottom_state = None
 
   for line in reversed(stack_lines):
     tokens = line.split()
@@ -655,12 +763,12 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
     kv = _ltd_kv(line)
 
     if keyword == "BOTTOM":
-      state = tokens[1].upper() if len(tokens) > 1 else ""
-      if state == "COVERED":
-        # BOTTOM is always the first line seen here (it's the last line in the file,
-        # and this loop walks in reverse) - z is still untouched at 0.0, so starting
-        # it at the ground plane's thickness instead shifts every subsequent slab/
-        # metal/via z by the same amount the plane itself will occupy below them
+      # BOTTOM is always the first line seen here (it's the last line in the file, and
+      # this loop walks in reverse) - z is still untouched at 0.0, so starting it at the
+      # ground plane's thickness instead shifts every subsequent slab/metal/via z by the
+      # same amount the plane itself will occupy below them
+      bottom_state = tokens[1].upper() if len(tokens) > 1 else ""
+      if bottom_state == "COVERED":
         groundplane_detected = True
         z = _GROUND_PLANE_THICKNESS_UM
       continue
@@ -688,13 +796,14 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
       z += thickness_um
       slabs.append(DielectricSlab(material_name, thickness_um))
 
-      mask_match = re.search(r'MASK=\{([^}]*)\}', line)
+      mask_match = _MASK_BRACE_RE.search(line)
       if mask_match:
-        for via_mask_name in mask_match.group(1).split():
-          mask = masks.get(via_mask_name)
+        for token in mask_match.group(1).split():
+          mask = _resolve_mask_token(token, masks, masks_by_layer)
           if mask is None:
-            warnings.append(f"Mask '{via_mask_name}' referenced in stack but not defined in BEGIN_MASK, skipped")
+            warnings.append(f"Mask '{token}' referenced in stack but not defined in BEGIN_MASK, skipped")
             continue
+          via_mask_name = mask["name"]
           op = operations.get(mask["operation"])
           if op is None or op[0] != "via":
             warnings.append(f"Mask '{via_mask_name}' is attached to a dielectric LAYER line but its "
@@ -713,22 +822,40 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
       continue
 
     if keyword == "INTERFACE":
-      mask_match = re.search(r'MASK=\{([^}]*)\}', line)
+      # SHIELD=... is an alternative way (seen in a real export, paired with "BOTTOM
+      # OPEN" instead of "BOTTOM COVERED") to mark a backside ground plane, positioned
+      # at a specific INTERFACE rather than as the stack's own bottom boundary. Only
+      # treated as equivalent to a covered bottom when it's genuinely at (or extremely
+      # near) the true bottom of the stack (z still ~0 at this point in the bottom-up
+      # walk) - a mid-stack shield has no verified real-world example to model
+      # correctly against, so it's surfaced as a warning instead of guessed at.
+      shield = kv.get("SHIELD")
+      if shield:
+        if z < _EPSILON_UM:
+          groundplane_detected = True
+        else:
+          warnings.append(
+              f"Shield/ground plane (SHIELD={shield}) detected mid-stack (not at the "
+              f"bottom) - has no GDSII layer number and was not modeled; add manually if needed.")
+        continue
+
+      mask_match = _MASK_BRACE_RE.search(line)
       if not mask_match:
         continue
-      for metal_mask_name in mask_match.group(1).split():
-        mask = masks.get(metal_mask_name)
+      for token in mask_match.group(1).split():
+        mask = _resolve_mask_token(token, masks, masks_by_layer)
         if mask is None:
-          warnings.append(f"Mask '{metal_mask_name}' referenced in stack but not defined in BEGIN_MASK, skipped")
+          warnings.append(f"Mask '{token}' referenced in stack but not defined in BEGIN_MASK, skipped")
           continue
+        metal_mask_name = mask["name"]
         op = operations.get(mask["operation"])
         if op is None or op[0] == "via":
           warnings.append(f"Mask '{metal_mask_name}' is attached to an INTERFACE line but its "
                            f"operation is DRILL - expected a metal, skipped")
           continue
-        if op[0] == "sheet":
-          warnings.append(f"Mask '{metal_mask_name}' uses a SHEET operation with no thickness "
-                           f"defined - skipped, add manually if needed")
+        if op[0] in ("sheet", "wall"):
+          warnings.append(f"Mask '{metal_mask_name}' uses a {op[0].upper()} operation with no "
+                           f"thickness defined - skipped, add manually if needed")
           continue
         mat_name = mask["material"]
         if mat_name not in materials:
@@ -738,9 +865,6 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
           materials[mat_name].color = mask["color"]
         thickness_um = op[1]
         existing = spans.get(metal_mask_name)
-        # INTRUDE is documented/observed as always positive in *.ltd (unlike *.subst's
-        # thick, which can be negative to mean "grows down") - min/max anyway, cheaply
-        # future-proofing this the same way _parse_subst's metal loop must for real.
         metal_zmin, metal_zmax = min(z, z + thickness_um), max(z, z + thickness_um)
         if existing is None:
           spans[metal_mask_name] = [mat_name, "metal", mask["gds_layer"], metal_zmin, metal_zmax]
@@ -752,8 +876,27 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
   if not slabs:
     raise ValueError("No usable dielectric slabs found in *.ltd file")
 
+  if bottom_state == "OPEN" and not groundplane_detected:
+    warnings.append("Bottom boundary (BOTTOM OPEN) detected - open/unbounded and not modeled; "
+                     "add a backside ground or substrate manually if needed.")
+
   layers = [LayerEntry(name=name, material_name=mat_name, kind=kind, gds_layer=gds_layer, zmin=zmin, zmax=zmax)
             for name, (mat_name, kind, gds_layer, zmin, zmax) in spans.items()]
+
+  # resolve deferred RESISTANCE=-only materials now that every Layer's real thickness is
+  # known: sheet-resistor only if every use of that material is genuinely zero-thickness,
+  # otherwise treated as a normal conductor with an equivalent bulk conductivity computed
+  # from Rs and the first non-zero thickness found (conductivity = 1/(Rs * thickness_m)) -
+  # see the note where pending_rs is populated above.
+  for name, rs in pending_rs.items():
+    uses = [l for l in layers if l.material_name == name]
+    nonzero = next((l for l in uses if (l.zmax - l.zmin) > _EPSILON_UM), None)
+    if nonzero is not None:
+      thickness_m = (nonzero.zmax - nonzero.zmin) * 1e-6
+      materials[name].conductivity = 1.0 / (rs * thickness_m)
+    else:
+      materials[name].kind = "sheet_resistor"
+      materials[name].rs = rs
 
   # slabs were built while walking the file in reverse (bottom-to-top), matching
   # _build_tree's expected bottom-to-top input order - the ground plane, if any,
@@ -761,7 +904,7 @@ def _parse_ltd(ltd_path, air_thickness_um, warnings):
   if groundplane_detected:
     slabs.insert(0, _ground_plane_slab(materials, warnings))
 
-  return slabs, layers, materials
+  return slabs, layers, materials, derived_layers
 
 
 def import_ltd(ltd_path, air_thickness_um):
@@ -774,7 +917,7 @@ def import_ltd(ltd_path, air_thickness_um):
       ImportResult
   """
   warnings = []
-  slabs, layers, materials = _parse_ltd(ltd_path, air_thickness_um, warnings)
-  _strip_common_material_suffix(materials, slabs, layers, warnings)
-  tree = _build_tree(slabs, layers, materials, warnings)
+  slabs, layers, materials, derived_layers = _parse_ltd(ltd_path, air_thickness_um, warnings)
+  _strip_common_material_suffix(materials, slabs, layers, warnings, derived_layers)
+  tree = _build_tree(slabs, layers, materials, warnings, derived_layers)
   return ImportResult(tree=tree, warnings=warnings)

--- a/src/setupEM/setup_common.py
+++ b/src/setupEM/setup_common.py
@@ -57,15 +57,18 @@ from gds2palace import *
 # by capability (not __version__ string matching, which is easy to drift out of
 # sync) so the app degrades exactly as far as it needs to and no further, rather
 # than crashing the moment a missing symbol is touched.
+#
+# The stackup writer (edit/save/validate) itself lives in setupEM now, not
+# gds2palace - it has no installed-version dependency, so there is nothing left
+# to detect for it here. Only parse_substrate()/read_file_description() (genuine
+# gds2palace-reader capabilities) still need a version guard.
 # ------------------------------------------------------------------
-GDS2PALACE_HAS_STACKUP_WRITER = hasattr(gds2palace, "stackup_writer")
 GDS2PALACE_HAS_PARSE_SUBSTRATE = hasattr(stackup_reader, "parse_substrate")
 GDS2PALACE_HAS_FILE_DESCRIPTION = hasattr(stackup_reader, "read_file_description")
 
-# Tools > Edit Stackup XML... needs both the writer module and parse_substrate()
-# (used for its live preview refresh); the Input Files tab's description display
-# only needs the reader-side lookup.
-GDS2PALACE_SUPPORTS_STACKUP_EDITOR = GDS2PALACE_HAS_STACKUP_WRITER and GDS2PALACE_HAS_PARSE_SUBSTRATE
+# Tools > Edit Stackup XML... needs parse_substrate() (used for its live preview
+# refresh); the Input Files tab's description display only needs the reader-side lookup.
+GDS2PALACE_SUPPORTS_STACKUP_EDITOR = GDS2PALACE_HAS_PARSE_SUBSTRATE
 GDS2PALACE_SUPPORTS_FILE_DESCRIPTION = GDS2PALACE_HAS_FILE_DESCRIPTION
 GDS2PALACE_OUTDATED = not (GDS2PALACE_SUPPORTS_STACKUP_EDITOR and GDS2PALACE_SUPPORTS_FILE_DESCRIPTION)
 
@@ -790,7 +793,15 @@ class VectorWidget(QWidget):
                         # place text for distance to dielectric boundary
 
                         painter.setPen(penBlack)
-                        dz = dielectric.zmax - metal.zmax
+                        # a metal is registered "inside" a dielectric by its zmin alone
+                        # (see util_stackup_reader.register_metals_inside()) - its zmax
+                        # can legitimately extend past that dielectric's own zmax into
+                        # the one(s) above (e.g. a thick metal sitting in a very thin
+                        # dielectric slab), which would otherwise show as a negative,
+                        # confusingly-worded "distance to the boundary above". Floor at
+                        # 0 - the metal is still drawn at its correct position/height,
+                        # this only affects this one label.
+                        dz = max(0.0, dielectric.zmax - metal.zmax)
                         if dz > 10:
                             heightstring = f'{dz:.1f}µm'
                         else:
@@ -815,7 +826,16 @@ class VectorWidget(QWidget):
             idx = np.argsort(stored_z)
             y_sorted = stored_y[idx]
             z_sorted = stored_z[idx]
-            z_to_y = interp1d(z_sorted, y_sorted, kind='cubic', fill_value='extrapolate')
+            # linear, not cubic: the z->y mapping is a layout position (screen height
+            # per dielectric is set by how many metals are stacked inside it, not by
+            # its physical thickness), so slope can change drastically between
+            # consecutive stored points - e.g. a thick, metal-free substrate maps to
+            # almost no screen height while a thin, via-packed dielectric maps to a
+            # lot. A cubic spline through data like that readily overshoots (Runge's
+            # phenomenon), and with fill_value='extrapolate' that overshoot is
+            # unbounded - enough to overflow the int coordinates drawRect() needs
+            # below. Linear interpolation/extrapolation is bounded by construction.
+            z_to_y = interp1d(z_sorted, y_sorted, kind='linear', fill_value='extrapolate')
 
             # next we draw the vias, based on the screen position of metals that we have stored
             # via position alternates between 3 positions along x axis

--- a/src/setupEM/stackup_editor.py
+++ b/src/setupEM/stackup_editor.py
@@ -40,12 +40,22 @@ from PySide6.QtWidgets import (
     QDialog, QWidget, QVBoxLayout, QHBoxLayout, QTabWidget,
     QTableWidget, QTableWidgetItem, QHeaderView,
     QPushButton, QComboBox, QLineEdit, QPlainTextEdit, QLabel, QFileDialog, QMessageBox,
-    QScrollArea, QColorDialog, QMenuBar,
+    QScrollArea, QColorDialog, QMenuBar, QInputDialog,
 )
 from PySide6.QtGui import QColor, QFontMetrics, QKeySequence, QAction
 from PySide6.QtCore import Qt, QTimer, Signal
 
-from gds2palace import stackup_reader, stackup_writer
+from gds2palace import stackup_reader
+
+# __package__ is None/"" when this module was loaded outside the setupEM package
+# (e.g. setupEM.py run directly), so relative import fails - same dual-mode pattern
+# used throughout setupEM.py/setup_common.py for their own sibling imports.
+if __package__ in (None, ""):
+  import stackup_writer
+  import momentum_import
+else:
+  from . import stackup_writer
+  from . import momentum_import
 
 # __package__ is None/"" when this file is run directly rather than imported
 # as part of the setupEM package, so relative import fails.
@@ -743,6 +753,18 @@ class StackupEditorWindow(QDialog):
 
         self.file_menu.addSeparator()
 
+        self.import_menu = self.file_menu.addMenu("&Import")
+
+        self.import_subst_action = QAction("ADS Momentum (*.subst + materials.matdb)...", self)
+        self.import_subst_action.triggered.connect(self._import_momentum_subst)
+        self.import_menu.addAction(self.import_subst_action)
+
+        self.import_ltd_action = QAction("ADS Momentum (*.ltd)...", self)
+        self.import_ltd_action.triggered.connect(self._import_momentum_ltd)
+        self.import_menu.addAction(self.import_ltd_action)
+
+        self.file_menu.addSeparator()
+
         self.save_action = QAction("&Save", self)
         self.save_action.setShortcut(QKeySequence.Save)
         self.save_action.triggered.connect(lambda: self.save())
@@ -766,6 +788,10 @@ class StackupEditorWindow(QDialog):
         self.convert_to_reference_action = QAction("Convert to Reference position format", self)
         self.convert_to_reference_action.triggered.connect(self._on_convert_to_reference_clicked)
         self.tools_menu.addAction(self.convert_to_reference_action)
+
+        self.convert_to_legacy_action = QAction("Convert to legacy format", self)
+        self.convert_to_legacy_action.triggered.connect(self._on_convert_to_legacy_clicked)
+        self.tools_menu.addAction(self.convert_to_legacy_action)
 
         self.view_menu = self.menu_bar.addMenu("&View")
 
@@ -1233,6 +1259,92 @@ class StackupEditorWindow(QDialog):
         self._reset_undo_baseline()
         self._revalidate_and_refresh()
 
+    # ---------- import from ADS Momentum ----------
+
+    def _prompt_air_thickness(self):
+        """Asks for the thickness of the open-boundary AIR region above the stack -
+           both ADS Momentum source formats leave this undefined (Momentum treats it
+           as an unbounded half-space), but the target schema needs a finite value to
+           bound the simulation domain.
+        Returns:
+            float or None: the entered thickness, or None if the user cancelled
+        """
+        value, ok = QInputDialog.getDouble(
+            self, "Top Air Thickness",
+            "Thickness of the open-boundary AIR region above the stack (um):",
+            300.0, 0.0, 1000000.0, decimals=2)
+        return value if ok else None
+
+    def _show_import_warnings(self, warnings):
+        if not warnings:
+            QMessageBox.information(self, "Import complete", "Stackup imported successfully.")
+            return
+        QMessageBox.information(
+            self, "Import warnings",
+            "Imported with warnings:\n\n" + "\n".join(f"- {w}" for w in warnings))
+
+    def _apply_import_result(self, result, source_label):
+        # current_filename deliberately left None, same as new_file() - an imported
+        # stackup is unsaved content the user should explicitly Save As, never
+        # something that could silently overwrite an existing file
+        self.tree = result.tree
+        self.current_filename = None
+        self._set_filename_label(f"(imported from {source_label}, unsaved)")
+        self._asked_about_implicit_dielectric_references = False
+        self._loaded_schema_version = self.tree.getroot().get("schemaVersion")
+        self._reload_all_editors()
+        self._reset_undo_baseline()
+        self._revalidate_and_refresh()
+        self._show_import_warnings(result.warnings)
+
+    def _import_momentum_subst(self):
+        previous_dir = os.path.dirname(self.current_filename) if self.current_filename else ""
+        subst_path, _ = QFileDialog.getOpenFileName(
+            self, "Import ADS Momentum Substrate", previous_dir, "*.subst;;*.*")
+        if not subst_path:
+            return
+
+        # per the *.subst format, a companion materials.matdb is always expected in
+        # the same folder - looked up automatically rather than asked for separately
+        matdb_path = os.path.join(os.path.dirname(subst_path), "materials.matdb")
+        if not os.path.isfile(matdb_path):
+            QMessageBox.critical(
+                self, "Error",
+                f"Could not find materials.matdb next to {os.path.basename(subst_path)}.\n\n"
+                "A *.subst file always requires a materials.matdb in the same folder.")
+            return
+
+        air_thickness = self._prompt_air_thickness()
+        if air_thickness is None:
+            return
+
+        try:
+            result = momentum_import.import_subst(subst_path, matdb_path, air_thickness)
+        except Exception as e:
+            QMessageBox.critical(self, "Import failed", f"Could not import {subst_path}:\n{e}")
+            return
+
+        self._apply_import_result(result, os.path.basename(subst_path))
+
+    def _import_momentum_ltd(self):
+        previous_dir = os.path.dirname(self.current_filename) if self.current_filename else ""
+        ltd_path, _ = QFileDialog.getOpenFileName(
+            self, "Import ADS Momentum Technology", previous_dir, "*.ltd;;*.*")
+        if not ltd_path:
+            return
+
+        air_thickness = self._prompt_air_thickness()
+        if air_thickness is None:
+            return
+
+        try:
+            result = momentum_import.import_ltd(ltd_path, air_thickness)
+        except Exception as e:
+            QMessageBox.critical(self, "Import failed", f"Could not import {ltd_path}:\n{e}")
+            return
+
+        self._apply_import_result(result, os.path.basename(ltd_path))
+
     def _reload_all_editors(self):
         root = self.tree.getroot()
         self.materials_editor.set_root(root)
@@ -1639,6 +1751,176 @@ class StackupEditorWindow(QDialog):
             lowest = min(dielectrics, key=lambda d: d.zmin)
             return lowest.name, "Bottom", lowest.zmin
         return None
+
+    # ---------- convert to legacy format ----------
+
+    def _on_convert_to_legacy_clicked(self):
+        if self.tree is None:
+            return
+
+        message = (
+            "Convert this stackup to the old schemaVersion \"2.0\" legacy format?\n\n"
+            "- Every Reference-positioned Layer is rewritten to absolute Zmin/Zmax. Every "
+            "Reference-positioned Dielectric is rewritten to plain Thickness (implicit "
+            "top-to-bottom stacking) wherever that alone still reproduces its current "
+            "position, falling back to absolute Zmin/Zmax only where it doesn't.\n"
+            "- Derived layers are removed, along with any Layer entry that exists only to "
+            "give a derived layer its Z-position (its Layer number was never real GDSII "
+            "geometry).\n"
+            "- Thermal data is removed: the Tables section, and Density/ThermalConductivity/"
+            "ThermalConductivityTable on every Material.\n\n"
+            "Resulting absolute positions stay exactly the same.")
+
+        reply = QMessageBox.question(self, "Convert to legacy format", message,
+                                      QMessageBox.Yes | QMessageBox.No)
+        if reply != QMessageBox.Yes:
+            return
+
+        try:
+            self._convert_to_legacy_format()
+        except (Exception, SystemExit) as e:
+            QMessageBox.warning(self, "Conversion failed",
+                                 f"Could not convert - current stackup could not be fully "
+                                 f"resolved:\n{e}")
+            return
+
+        # this conversion's whole point is implicit Thickness-based Dielectric stacking -
+        # immediately re-offering to make it Reference-explicit again (a schemaVersion "3.0"
+        # feature this conversion just removed) at the next Save would be self-contradictory,
+        # so treat "asked" as already settled for the rest of this editing session
+        self._asked_about_implicit_dielectric_references = True
+
+        self._reload_all_editors()
+        self._on_changed(structural=True)
+
+    def _convert_to_legacy_format(self):
+        """Rewrites every Reference-positioned Layer/Dielectric to absolute positioning
+           (preferring plain Thickness-based implicit stacking for a Dielectric wherever
+           that alone reproduces its current resolved position), removes DerivedLayers
+           (and any Layer entry that exists only to give a derived layer its Z-position),
+           removes thermal data (Tables, and Density/ThermalConductivity/
+           ThermalConductivityTable on every Material), and sets schemaVersion to "2.0" -
+           the format read before Reference/DerivedLayers/Tables existed. The inverse of
+           _convert_to_reference_format() above.
+        """
+        root = self.tree.getroot()
+
+        # ground truth: fully resolved positions exactly as the reader sees them today,
+        # captured once up front so every lookup below is against the *original* file,
+        # never against a partially-converted in-progress state
+        materials_list, dielectrics_list, metals_list = stackup_reader.parse_substrate(root)
+        dielectric_by_name = {dielectric.name: dielectric for dielectric in dielectrics_list.dielectrics}
+
+        # ---- Layers: Reference -> absolute Zmin/Zmax (no "implicit" alternative exists
+        # for Layers - only Dielectrics can fall back to Thickness-based stacking) ----
+        metal_by_name = {metal.name: metal for metal in metals_list.metals}
+        for layer_el in self._layers_container(root):
+            if not layer_el.get("Reference"):
+                continue
+            metal = metal_by_name.get(layer_el.get("Name"))
+            if metal is None:
+                continue
+            layer_el.set("Zmin", f"{metal.zmin:.4f}")
+            layer_el.set("Zmax", f"{metal.zmax:.4f}")
+            for attr in ("Reference", "ReferenceEdge"):
+                if attr in layer_el.attrib:
+                    del layer_el.attrib[attr]
+
+        # ---- Dielectrics: prefer implicit Thickness+order, fall back to absolute
+        # Zmin/Zmax only where needed ----
+        self._convert_dielectrics_to_legacy(root, dielectric_by_name)
+
+        # ---- remove derived layers, and any Layer entry that exists only for one ----
+        derived_layers_el = stackup_writer.get_derived_layers_element(root)
+        if derived_layers_el is not None:
+            derived_target_numbers = set()
+            for derived_el in derived_layers_el.findall("DerivedLayer"):
+                layernum = derived_el.get("Layer")
+                if layernum is not None:
+                    try:
+                        derived_target_numbers.add(int(layernum))
+                    except ValueError:
+                        pass
+            root.find("ELayers").remove(derived_layers_el)
+
+            for layer_el in self._layers_container(root):
+                layernum = layer_el.get("Layer")
+                if layernum is None:
+                    continue
+                try:
+                    if int(layernum) in derived_target_numbers:
+                        stackup_writer.remove_layer(root, layer_el)
+                except ValueError:
+                    pass
+
+        # ---- remove thermal data: Tables section, and thermal attributes on Materials ----
+        tables_el = root.find("Tables")
+        if tables_el is not None:
+            root.remove(tables_el)
+
+        for material_el in self._materials_container(root):
+            for attr in ("Density", "ThermalConductivity", "ThermalConductivityTable"):
+                if attr in material_el.attrib:
+                    del material_el.attrib[attr]
+
+        # this comment's claim (minimum reader version needed for Reference-relative
+        # positioning) no longer applies once every Reference has been removed above
+        for child in list(root):
+            if child.tag is ET.Comment and (child.text or "").strip().startswith(
+                    stackup_writer.REFERENCE_FORMAT_COMMENT_PREFIX):
+                root.remove(child)
+
+        root.set("schemaVersion", "2.0")
+
+    def _convert_dielectrics_to_legacy(self, root, dielectric_by_name):
+        """Decides, per Dielectric, whether plain Thickness (implicit top-to-bottom
+           stacking) alone still reproduces its ground-truth resolved position, falling
+           back to absolute Zmin/Zmax for the ones where it doesn't - then applies that
+           decision to the real elements.
+
+           Single greedy pass, bottom-to-top - the same order/direction as the reader's own
+           dielectric_layers_list._assign_implicit_references(). A Dielectric is implicit-
+           compatible exactly when its ground-truth zmin equals the top edge of the nearest
+           dielectric below it that is *itself* implicit-compatible (or 0, if there is none) -
+           an absolute-fallback Dielectric is transparent to this chain, exactly like the real
+           implicit-stacking algorithm treats it, so walking bottom-to-top and carrying
+           forward only the last implicit dielectric's zmax reproduces its decisions exactly,
+           with no need to iterate/guess against a series of what-if hypotheses.
+        """
+        dielectric_elements = self._dielectrics_container(root)
+        epsilon = 1e-4
+
+        last_implicit_zmax = 0.0  # anchor: z=0 once nothing implicit sits below yet
+        implicit_names = set()
+        for element in reversed(dielectric_elements):
+            ground_truth = dielectric_by_name.get(element.get("Name"))
+            if ground_truth is None:
+                continue
+            if abs(ground_truth.zmin - last_implicit_zmax) < epsilon:
+                implicit_names.add(element.get("Name"))
+                last_implicit_zmax = ground_truth.zmax
+            # else: falls back to absolute below: transparent to the chain, so
+            # last_implicit_zmax carries forward unchanged to the next (higher) Dielectric
+
+        for element in dielectric_elements:
+            name = element.get("Name")
+            ground_truth = dielectric_by_name.get(name)
+            if ground_truth is None:
+                continue
+            for attr in ("Reference", "ReferenceEdge"):
+                if attr in element.attrib:
+                    del element.attrib[attr]
+            if name in implicit_names:
+                element.set("Thickness", f"{ground_truth.thickness:.4f}")
+                for attr in ("Zmin", "Zmax"):
+                    if attr in element.attrib:
+                        del element.attrib[attr]
+            else:
+                element.set("Zmin", f"{ground_truth.zmin:.4f}")
+                element.set("Zmax", f"{ground_truth.zmax:.4f}")
+                if "Thickness" in element.attrib:
+                    del element.attrib["Thickness"]
+            # Boundary, if present, is orthogonal to position mode and stays untouched
 
     # ---------- file description ----------
 

--- a/src/setupEM/stackup_writer.py
+++ b/src/setupEM/stackup_writer.py
@@ -1,0 +1,815 @@
+########################################################################
+#
+# Copyright 2025 Volker Muehlhaus and IHP PDK Authors
+#
+# Licensed under the GNU General Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+########################################################################
+
+"""
+Load/edit/save/validate stackup XML files (see XML_stackup_format.md) at the
+xml.etree.ElementTree level, independent of any GUI toolkit.
+
+This module is deliberately kept separate from gds2palace's util_stackup_reader.py:
+the reader turns XML into the read-only object model (stackup_material,
+dielectric_layer, metal_layer, ...) used by the rest of gds2palace, while this
+module is for tools that need to load a file, edit it (materials/dielectrics/
+layers), and write it back out - such as this GUI stackup editor - while leaving
+any parts of the file they don't understand (e.g. Tables and XML comments)
+completely untouched. It lives here in setupEM rather than in gds2palace because
+setupEM is its only real consumer - gds2palace's own workflow only ever reads
+stackup files, never edits/writes them.
+"""
+
+__version__ = "1.4.0"
+
+import xml.etree.ElementTree as ET
+
+from gds2palace import stackup_reader
+
+VALID_MATERIAL_TYPES = ("Conductor", "Dielectric", "Semiconductor", "Resistor")
+VALID_LAYER_TYPES = ("conductor", "via", "dielectric", "sheet")
+VALID_DERIVED_OPERATIONS = ("AND", "OR", "XOR", "NOT", "SIZE")
+
+# Attribute order to enforce on save for a <Layer>/<Dielectric> that has Reference set,
+# so Reference/ReferenceEdge always read as "what this is positioned against" right next
+# to the element's identity, ahead of the numeric Material/Layer#/Zmin/Zmax/etc. details -
+# rather than landing wherever they happened to be set (typically last, since Reference is
+# usually added to an element that already has its other attributes). Elements without
+# Reference are left with whatever attribute order they already have.
+_LAYER_REFERENCE_ATTR_ORDER = ("Name", "Type", "Reference", "ReferenceEdge", "Material", "Layer", "Zmin", "Zmax")
+_DIELECTRIC_REFERENCE_ATTR_ORDER = ("Name", "Reference", "ReferenceEdge", "Material", "Thickness", "Zmin", "Zmax", "Boundary")
+
+
+def _reorder_attributes(element, canonical_order):
+  """Reorders element.attrib in place to match canonical_order; any attribute not listed
+     there keeps its existing relative order, appended after the canonical ones (so an
+     unexpected/future attribute is never silently dropped, just not specially placed).
+  """
+  remaining = dict(element.attrib)
+  ordered = {}
+  for key in canonical_order:
+    if key in remaining:
+      ordered[key] = remaining.pop(key)
+  ordered.update(remaining)
+  element.attrib.clear()
+  element.attrib.update(ordered)
+
+
+def _comment_preserving_parser():
+  """XML parser that keeps <!-- comments --> as Comment nodes in the tree, instead of
+     silently dropping them (the default xml.etree behavior), so a load/save round
+     trip does not lose comments in sections this module never edits.
+  """
+  target = ET.TreeBuilder(insert_comments=True)
+  return ET.XMLParser(target=target)
+
+
+# -------------------- load / new / save --------------------
+
+def load_stackup_tree(filename):
+  """Load a stackup XML file into an editable ElementTree, preserving comments.
+  Args:
+      filename (string): path to the stackup XML file
+  Returns:
+      xml.etree.ElementTree.ElementTree
+  """
+  return ET.parse(filename, parser=_comment_preserving_parser())
+
+
+def new_stackup_tree(length_unit="um", schema_version="2.0"):
+  """Create a minimal empty stackup tree (empty Materials/Dielectrics/Layers), for
+     starting a new stackup file from scratch in an editor.
+  Returns:
+      xml.etree.ElementTree.ElementTree
+  """
+  root = ET.Element("Stackup", {"schemaVersion": schema_version})
+  ET.SubElement(root, "Materials")
+  elayers = ET.SubElement(root, "ELayers", {"LengthUnit": length_unit})
+  ET.SubElement(elayers, "Dielectrics")
+  ET.SubElement(elayers, "Layers")
+  return ET.ElementTree(root)
+
+
+GENERATOR_COMMENT_PREFIX = "Created/modified using the XML Stackup Editor in"
+DESCRIPTION_COMMENT_PREFIX = "File description:"
+_HEADER_SEPARATOR_TEXT = "=" * 60
+
+
+def _sanitize_comment_text(text):
+  """XML comments may not contain '--' or end in '-'; make free-form user text
+     safe to embed as a Comment node's .text without raising on write().
+  """
+  text = text.replace("--", "- -")
+  return text.rstrip("-")
+
+
+def _is_header_comment(comment_element):
+  """True if this Comment node looks like one this module previously wrote as part
+     of the header block (generator stamp / separator / file description), so a
+     re-stamp can cleanly remove the old block before writing a fresh one.
+  """
+  text = (comment_element.text or "").strip()
+  return (text.startswith(GENERATOR_COMMENT_PREFIX)
+          or text.startswith(DESCRIPTION_COMMENT_PREFIX)
+          or text == _HEADER_SEPARATOR_TEXT)
+
+
+def stamp_header_comments(root, app_name, description=""):
+  """Insert or update the header comment block at the very top of the stackup root:
+     a fixed "created with" stamp, and - only if description is non-empty - a
+     separator line followed by the user-supplied file description. Idempotent:
+     replaces a previously-stamped header block instead of stacking a new one on
+     every save; any other pre-existing comments/elements are left untouched.
+  Args:
+      root (xml.etree.ElementTree.Element): the <Stackup> root element
+      app_name (string): name of the host application (e.g. "setupEM", "setupThermal")
+      description (string): optional free-text description of the file
+  """
+  children = list(root)
+  while children and children[0].tag is ET.Comment and _is_header_comment(children[0]):
+    root.remove(children[0])
+    children = list(root)
+
+  nodes = [ET.Comment(f" {_sanitize_comment_text(GENERATOR_COMMENT_PREFIX + ' ' + app_name)} ")]
+  description = _sanitize_comment_text((description or "").strip())
+  if description:
+    nodes.append(ET.Comment(f" {_HEADER_SEPARATOR_TEXT} "))
+    nodes.append(ET.Comment(f" {DESCRIPTION_COMMENT_PREFIX} {description} "))
+
+  for i, node in enumerate(nodes):
+    root.insert(i, node)
+
+
+def get_file_description(root):
+  """Return the free-text file description previously stamped by the editor (see
+     stamp_header_comments), or "" if none is present.
+  Args:
+      root (xml.etree.ElementTree.Element): the <Stackup> root element
+  """
+  for child in root:
+    if child.tag is ET.Comment:
+      text = (child.text or "").strip()
+      if text.startswith(DESCRIPTION_COMMENT_PREFIX):
+        return text[len(DESCRIPTION_COMMENT_PREFIX):].strip()
+  return ""
+
+
+REFERENCE_FORMAT_COMMENT_PREFIX = "Reference-relative positioning requires gds2palace util_stackup_reader.py version"
+
+
+def stamp_reference_format_comment(root, min_reader_version):
+  """Insert or update a comment noting the minimum gds2palace reader version needed to
+     correctly resolve this file's Reference-relative positioning. Meant to be called once,
+     right after a Dielectric/Layer set actually starts using Reference (e.g. by "Convert to
+     Reference position format" in the Stackup Editor) - not on every save, since it's a
+     one-time fact about the file's content, not something that needs refreshing like the
+     generator/description stamp. Idempotent: replaces a previous stamp of this same comment
+     rather than stacking a new one if called again (e.g. re-running the conversion).
+  Args:
+      root (xml.etree.ElementTree.Element): the <Stackup> root element
+      min_reader_version (string): util_stackup_reader.__version__ of the reader used to
+        perform the conversion, taken as the minimum version able to read the result back
+  """
+  for child in list(root):
+    if child.tag is ET.Comment and (child.text or "").strip().startswith(REFERENCE_FORMAT_COMMENT_PREFIX):
+      root.remove(child)
+
+  # goes right after the existing header block (generator stamp / description, if any) -
+  # stamp_header_comments() only ever touches its own contiguous run at index 0, so
+  # inserting immediately after it keeps this comment from being disturbed by a later re-save
+  insert_index = 0
+  for child in root:
+    if child.tag is ET.Comment:
+      insert_index += 1
+    else:
+      break
+  root.insert(insert_index, ET.Comment(f" {REFERENCE_FORMAT_COMMENT_PREFIX} {min_reader_version} or newer "))
+
+
+def required_schema_version(root):
+  """The minimum schemaVersion this stackup's current content actually needs: "3.0" if
+     any Dielectric or Layer uses Reference-relative positioning (the feature that
+     bumped the format - see util_stackup_reader.SUPPORTED_SCHEMA_VERSION), "2.0"
+     otherwise. Used by save_stackup_tree() to catch schemaVersion="2.0" silently
+     becoming a lie about the file's actual content - e.g. a Dielectric/Layer gaining
+     a Reference attribute through some path other than "Convert to Reference position
+     format" (which already sets schemaVersion itself), such as the Stackup Editor's
+     one-time "make implicit dielectric stacking explicit?" offer at save time.
+  Args:
+      root (xml.etree.ElementTree.Element): the <Stackup> root element
+  Returns:
+      string: "2.0" or "3.0"
+  """
+  dielectrics_el = get_dielectrics_element(root)
+  if dielectrics_el is not None and any(el.get("Reference") for el in dielectrics_el.findall("Dielectric")):
+    return "3.0"
+  layers_el = get_layers_element(root)
+  if layers_el is not None and any(el.get("Reference") for el in layers_el.findall("Layer")):
+    return "3.0"
+  return "2.0"
+
+
+def _sort_layers_by_resulting_zmin (root):
+  """Reorders <Layer> children within <Layers> by resulting (resolved absolute) Zmin,
+     highest first - matching how <Dielectric> already reads top-to-bottom in the file.
+     Uses the reader to resolve Reference-based offsets into real absolute z, since a
+     Reference-based Layer's own Zmin attribute is just an offset relative to whatever it
+     references, not a meaningful sort key by itself. Purely a save-time presentation
+     choice (file order has no semantic meaning to the reader); silently leaves the
+     current order untouched if the data can't be fully resolved right now (e.g. a
+     mid-edit invalid state) - sort order isn't worth blocking a save over.
+
+     Any comment in <Layers> is moved to the very beginning of the section (ahead of the
+     optional <Substrate Offset=".../">, ahead of every <Layer>) rather than left in its
+     original slot: sorting means whichever <Layer> a comment used to introduce may no
+     longer sit next to it, so leaving it in place would misleadingly suggest it still
+     describes whatever ended up there instead.
+  """
+  layers_el = get_layers_element(root)
+  if layers_el is None:
+    return
+  layer_elements = layers_el.findall("Layer")
+  if len(layer_elements) < 2:
+    return
+
+  try:
+    _, _, metals_list = stackup_reader.parse_substrate(root)
+  except (Exception, SystemExit):
+    return
+
+  zmin_by_name = {metal.name: metal.zmin for metal in metals_list.metals}
+  sorted_layers = sorted(layer_elements, key=lambda el: zmin_by_name.get(el.get("Name"), float("-inf")), reverse=True)
+
+  children = list(layers_el)
+  comments = [child for child in children if child.tag is ET.Comment]
+  substrate_el = layers_el.find("Substrate")
+  new_children = comments + ([substrate_el] if substrate_el is not None else []) + sorted_layers
+
+  for child in children:
+    layers_el.remove(child)
+  for child in new_children:
+    layers_el.append(child)
+
+
+def save_stackup_tree(tree, filename):
+  """Write a stackup tree back to disk with consistent indentation.
+
+  Note: this re-serializes the whole document, so exact original whitespace and
+  attribute order may change (any Reference-using Layer/Dielectric has its attribute
+  order deliberately normalized - see _reorder_attributes()), and <Layer> entries are
+  reordered by resulting Zmin, descending - see _sort_layers_by_resulting_zmin(). Comments
+  and all element content are preserved.
+
+  Also self-corrects schemaVersion="2.0" up to "3.0" if the content now needs it (see
+  required_schema_version()) - every write goes through here, so this is the one place
+  that reliably catches it regardless of which code path added the Reference attribute.
+  Deliberately one-directional: never downgrades "3.0" back to "2.0" even if nothing
+  currently uses Reference, since that's a content decision ("Convert to legacy format"
+  makes it explicitly), not just a version-string correction.
+  Args:
+      tree (xml.etree.ElementTree.ElementTree): tree to write, as returned by
+        load_stackup_tree() or new_stackup_tree()
+      filename (string): path to write to
+  """
+  root = tree.getroot()
+
+  if required_schema_version(root) == "3.0" and root.get("schemaVersion") != "3.0":
+    root.set("schemaVersion", "3.0")
+    stamp_reference_format_comment(root, stackup_reader.__version__)
+
+  layers_el = get_layers_element(root)
+  if layers_el is not None:
+    for layer_el in layers_el.findall("Layer"):
+      if layer_el.get("Reference"):
+        _reorder_attributes(layer_el, _LAYER_REFERENCE_ATTR_ORDER)
+
+  dielectrics_el = get_dielectrics_element(root)
+  if dielectrics_el is not None:
+    for dielectric_el in dielectrics_el.findall("Dielectric"):
+      if dielectric_el.get("Reference"):
+        _reorder_attributes(dielectric_el, _DIELECTRIC_REFERENCE_ATTR_ORDER)
+
+  _sort_layers_by_resulting_zmin(root)
+
+  ET.indent(tree, space="  ")
+  tree.write(filename, xml_declaration=True, encoding="UTF-8")
+
+
+# -------------------- structural accessors --------------------
+
+def get_materials_element(root):
+  return root.find("Materials")
+
+
+def get_dielectrics_element(root):
+  return root.find("ELayers/Dielectrics")
+
+
+def get_layers_element(root):
+  return root.find("ELayers/Layers")
+
+
+def get_substrate_offset_element(root):
+  layers_el = get_layers_element(root)
+  if layers_el is None:
+    return None
+  return layers_el.find("Substrate")
+
+
+def get_derived_layers_element(root, create=False):
+  """<DerivedLayers> is optional and, unlike Dielectrics/Layers, may not exist yet.
+  Args:
+      create (bool): if True and the element is missing, create (and return) it
+  """
+  elayers = root.find("ELayers")
+  derived_layers_el = elayers.find("DerivedLayers") if elayers is not None else None
+  if derived_layers_el is None and create and elayers is not None:
+    derived_layers_el = ET.SubElement(elayers, "DerivedLayers")
+  return derived_layers_el
+
+
+# -------------------- Material --------------------
+
+def add_material(root, **attrs):
+  """Append a new <Material> element. Keyword args become attributes (None/"" skipped).
+  Returns:
+      xml.etree.ElementTree.Element: the new Material element
+  """
+  materials_el = get_materials_element(root)
+  el = ET.SubElement(materials_el, "Material")
+  for key, value in attrs.items():
+    if value is not None and value != "":
+      el.set(key, str(value))
+  return el
+
+
+def remove_material(root, element):
+  get_materials_element(root).remove(element)
+
+
+# -------------------- Dielectric --------------------
+
+def add_dielectric(root, index=None, **attrs):
+  """Insert a new <Dielectric> element. Order in <Dielectrics> is top-to-bottom and
+     meaningful, so callers can pass index to control where it lands (default: end).
+  Returns:
+      xml.etree.ElementTree.Element: the new Dielectric element
+  """
+  dielectrics_el = get_dielectrics_element(root)
+  el = ET.Element("Dielectric")
+  for key, value in attrs.items():
+    if value is not None and value != "":
+      el.set(key, str(value))
+  if index is None or index >= len(dielectrics_el):
+    dielectrics_el.append(el)
+  else:
+    dielectrics_el.insert(index, el)
+  return el
+
+
+def remove_dielectric(root, element):
+  get_dielectrics_element(root).remove(element)
+
+
+def move_dielectric(root, element, direction):
+  """Move a Dielectric element within its parent, to reorder the stack.
+  Args:
+      element (xml.etree.ElementTree.Element): the Dielectric element to move
+      direction (int): -1 to move earlier (up), +1 to move later (down)
+  """
+  dielectrics_el = get_dielectrics_element(root)
+  children = list(dielectrics_el)
+  index = children.index(element)
+  new_index = index + direction
+  if 0 <= new_index < len(children):
+    dielectrics_el.remove(element)
+    dielectrics_el.insert(new_index, element)
+
+
+# -------------------- Layer / Substrate offset --------------------
+
+def add_layer(root, **attrs):
+  """Append a new <Layer> element. Keyword args become attributes (None/"" skipped).
+  Returns:
+      xml.etree.ElementTree.Element: the new Layer element
+  """
+  layers_el = get_layers_element(root)
+  el = ET.SubElement(layers_el, "Layer")
+  for key, value in attrs.items():
+    if value is not None and value != "":
+      el.set(key, str(value))
+  return el
+
+
+def remove_layer(root, element):
+  get_layers_element(root).remove(element)
+
+
+def set_substrate_offset(root, value):
+  """Add, update, or remove the single optional <Substrate Offset="..."/> element.
+  Args:
+      value: new offset (numeric or numeric string), or None/0 to remove the element
+  Returns:
+      xml.etree.ElementTree.Element or None: the Substrate element, or None if removed
+  """
+  layers_el = get_layers_element(root)
+  existing = layers_el.find("Substrate")
+
+  if value is None or value == "" or float(value) == 0:
+    if existing is not None:
+      layers_el.remove(existing)
+    return None
+
+  if existing is None:
+    existing = ET.Element("Substrate")
+    layers_el.insert(0, existing)
+  existing.set("Offset", str(value))
+  return existing
+
+
+# -------------------- DerivedLayer --------------------
+
+def add_derived_layer(root, **attrs):
+  """Append a new <DerivedLayer> element, creating <DerivedLayers> if this is the
+     first one. Keyword args become attributes (None/"" skipped); use set_operands()
+     separately to add its <Operand> children.
+  Returns:
+      xml.etree.ElementTree.Element: the new DerivedLayer element
+  """
+  derived_layers_el = get_derived_layers_element(root, create=True)
+  el = ET.SubElement(derived_layers_el, "DerivedLayer")
+  for key, value in attrs.items():
+    if value is not None and value != "":
+      el.set(key, str(value))
+  return el
+
+
+def remove_derived_layer(root, element):
+  """Remove a <DerivedLayer> element, and drop the now-empty <DerivedLayers>
+  container too if that was the last one (keeps a from-scratch file clean).
+  """
+  derived_layers_el = get_derived_layers_element(root)
+  if derived_layers_el is None:
+    return
+  derived_layers_el.remove(element)
+  if len(derived_layers_el) == 0:
+    root.find("ELayers").remove(derived_layers_el)
+
+
+def get_operand_layers(element):
+  """Layer numbers (as strings, in document order) of a DerivedLayer's <Operand> children."""
+  return [operand.get("Layer") for operand in element.findall("Operand")]
+
+
+def set_operands(element, layer_numbers):
+  """Replace a DerivedLayer element's <Operand> children with one per given layer
+  number, in order - order matters for Operation="NOT" (first operand minus the rest).
+  Args:
+      layer_numbers (list of str/int): GDSII or other-DerivedLayer layer numbers
+  """
+  for existing in element.findall("Operand"):
+    element.remove(existing)
+  for layernum in layer_numbers:
+    ET.SubElement(element, "Operand", {"Layer": str(layernum)})
+
+
+# -------------------- validation --------------------
+
+def _is_float(value):
+  try:
+    float(value)
+    return True
+  except (TypeError, ValueError):
+    return False
+
+
+def _is_int(value):
+  try:
+    int(value)
+    return True
+  except (TypeError, ValueError):
+    return False
+
+
+def validate_stackup(root):
+  """Validate Materials/Dielectrics/Layers/DerivedLayers against the rules in
+     XML_stackup_format.md. Tables is intentionally not checked here (not editable yet).
+  Args:
+      root (xml.etree.ElementTree.Element): root <Stackup> element
+  Returns:
+      list of str: human-readable problems found, empty if the file is valid
+  """
+  errors = []
+
+  materials_el = get_materials_element(root)
+  material_names = []
+  if materials_el is not None:
+    for el in materials_el.findall("Material"):
+      name = el.get("Name")
+      mtype = el.get("Type")
+      label = name or "<unnamed material>"
+
+      if not name:
+        errors.append("Material is missing required attribute 'Name'")
+      elif name in material_names:
+        errors.append(f"Duplicate material Name '{name}'")
+      else:
+        material_names.append(name)
+
+      if not mtype:
+        errors.append(f"Material '{label}' is missing required attribute 'Type'")
+      elif mtype.upper() not in [t.upper() for t in VALID_MATERIAL_TYPES]:
+        errors.append(f"Material '{label}' has invalid Type '{mtype}' (must be one of {VALID_MATERIAL_TYPES})")
+
+      for attr in ("Permittivity", "DielectricLossTangent", "Conductivity", "Rs", "Density", "ThermalConductivity"):
+        value = el.get(attr)
+        if value is not None and value != "" and not _is_float(value):
+          errors.append(f"Material '{label}' has non-numeric {attr}='{value}'")
+
+  dielectrics_el = get_dielectrics_element(root)
+  dielectric_names = []
+  if dielectrics_el is not None:
+    dielectric_elements = dielectrics_el.findall("Dielectric")
+
+    # collect all dielectric names up front (order in <Dielectrics> is meaningful for implicit
+    # stacking, but a Reference may still point at a Dielectric defined later in the file)
+    for el in dielectric_elements:
+      name = el.get("Name")
+      if not name:
+        continue
+      if name in dielectric_names:
+        errors.append(f"Duplicate dielectric Name '{name}'")
+      else:
+        dielectric_names.append(name)
+
+    for el in dielectric_elements:
+      name = el.get("Name")
+      material = el.get("Material")
+      label = name or "<unnamed dielectric>"
+
+      if not name:
+        errors.append("Dielectric is missing required attribute 'Name'")
+
+      if not material:
+        errors.append(f"Dielectric '{label}' is missing required attribute 'Material'")
+      elif material not in material_names:
+        errors.append(f"Dielectric '{label}' references undefined Material '{material}'")
+
+      thickness = el.get("Thickness")
+      zmin = el.get("Zmin")
+      zmax = el.get("Zmax")
+      has_thickness = thickness is not None and thickness != ""
+      has_zmin = zmin is not None and zmin != ""
+      has_zmax = zmax is not None and zmax != ""
+      reference = el.get("Reference")
+
+      if reference:
+        # Reference set: Zmin (optional, default 0) and Zmax (optional, default
+        # Zmin+Thickness) are offsets - unlike absolute mode, Zmin alone isn't required,
+        # but something has to size the dielectric (Zmax or Thickness)
+        if not has_zmax and not has_thickness:
+          errors.append(f"Dielectric '{label}' has Reference set but needs either Zmax or Thickness to size it")
+        if has_zmin and not _is_float(zmin):
+          errors.append(f"Dielectric '{label}' has non-numeric Zmin='{zmin}'")
+        if has_zmax and not _is_float(zmax):
+          errors.append(f"Dielectric '{label}' has non-numeric Zmax='{zmax}'")
+        if has_thickness and not _is_float(thickness):
+          errors.append(f"Dielectric '{label}' has non-numeric Thickness='{thickness}'")
+
+        if reference not in dielectric_names:
+          errors.append(f"Dielectric '{label}' has Reference '{reference}' which matches no Dielectric")
+
+        reference_edge = el.get("ReferenceEdge")
+        if reference_edge is not None and reference_edge != "" and reference_edge.upper() not in ("TOP", "BOTTOM"):
+          errors.append(f"Dielectric '{label}' has invalid ReferenceEdge '{reference_edge}' (must be Top or Bottom)")
+      else:
+        has_zminmax = has_zmin and has_zmax
+        if not has_thickness and not has_zminmax:
+          errors.append(f"Dielectric '{label}' needs either Thickness or both Zmin and Zmax")
+        if has_thickness and not _is_float(thickness):
+          errors.append(f"Dielectric '{label}' has non-numeric Thickness='{thickness}'")
+        if has_zminmax:
+          if not _is_float(zmin):
+            errors.append(f"Dielectric '{label}' has non-numeric Zmin='{zmin}'")
+          if not _is_float(zmax):
+            errors.append(f"Dielectric '{label}' has non-numeric Zmax='{zmax}'")
+
+      boundary = el.get("Boundary")
+      if boundary is not None and boundary != "" and not _is_int(boundary):
+        errors.append(f"Dielectric '{label}' has non-integer Boundary='{boundary}'")
+
+    # circular Dielectric -> Dielectric Reference check (Reference only ever targets another
+    # Dielectric, so - unlike Layer's Reference - there's no ambiguous-namespace case here)
+    dielectric_reference_target = {}
+    for el in dielectric_elements:
+      name = el.get("Name")
+      reference = el.get("Reference")
+      if name and reference and reference in dielectric_names:
+        dielectric_reference_target[name] = reference
+
+    resolved_dielectric_names = set(dielectric_names) - set(dielectric_reference_target.keys())
+    remaining_dielectric_refs = dict(dielectric_reference_target)
+    progress = True
+    while progress and remaining_dielectric_refs:
+      progress = False
+      for name, target in list(remaining_dielectric_refs.items()):
+        if target in resolved_dielectric_names:
+          resolved_dielectric_names.add(name)
+          del remaining_dielectric_refs[name]
+          progress = True
+    if remaining_dielectric_refs:
+      errors.append(f"Circular Dielectric Reference detected among: {sorted(remaining_dielectric_refs.keys())}")
+
+  layers_el = get_layers_element(root)
+  layer_numbers = set()
+  layer_names = []
+  if layers_el is not None:
+    layer_elements = layers_el.findall("Layer")
+
+    # collect all layer names up front (order in <Layers> is not meaningful, so a
+    # Layer's Reference may point to another Layer defined later in the file)
+    for el in layer_elements:
+      name = el.get("Name")
+      if not name:
+        continue
+      if name in layer_names:
+        errors.append(f"Duplicate layer Name '{name}'")
+      else:
+        layer_names.append(name)
+
+    for el in layer_elements:
+      name = el.get("Name")
+      ltype = el.get("Type")
+      material = el.get("Material")
+      zmin = el.get("Zmin")
+      zmax = el.get("Zmax")
+      layernum = el.get("Layer")
+      label = name or "<unnamed layer>"
+      if layernum is not None and _is_int(layernum):
+        layer_numbers.add(int(layernum))
+
+      if not name:
+        errors.append("Layer is missing required attribute 'Name'")
+      if not ltype:
+        errors.append(f"Layer '{label}' is missing required attribute 'Type'")
+      elif ltype.upper() not in [t.upper() for t in VALID_LAYER_TYPES]:
+        errors.append(f"Layer '{label}' has invalid Type '{ltype}' (must be one of {VALID_LAYER_TYPES})")
+
+      if not material:
+        errors.append(f"Layer '{label}' is missing required attribute 'Material'")
+      elif material not in material_names:
+        errors.append(f"Layer '{label}' references undefined Material '{material}'")
+
+      if zmin is None or zmin == "":
+        errors.append(f"Layer '{label}' is missing required attribute 'Zmin'")
+      elif not _is_float(zmin):
+        errors.append(f"Layer '{label}' has non-numeric Zmin='{zmin}'")
+
+      if zmax is None or zmax == "":
+        errors.append(f"Layer '{label}' is missing required attribute 'Zmax'")
+      elif not _is_float(zmax):
+        errors.append(f"Layer '{label}' has non-numeric Zmax='{zmax}'")
+
+      if layernum is None or layernum == "":
+        errors.append(f"Layer '{label}' is missing required attribute 'Layer'")
+      elif not _is_int(layernum):
+        errors.append(f"Layer '{label}' has non-integer Layer='{layernum}'")
+
+      if ltype and zmin is not None and zmax is not None and _is_float(zmin) and _is_float(zmax):
+        is_zero_thickness = float(zmin) == float(zmax)
+        if ltype.upper() == "SHEET" and not is_zero_thickness:
+          errors.append(f"Layer '{label}' has Type=\"sheet\" but Zmax != Zmin (sheet layers must have zero thickness)")
+
+      reference = el.get("Reference")
+      if reference:
+        dielectric_match = reference in dielectric_names
+        layer_match = reference in layer_names
+        if dielectric_match and layer_match:
+          errors.append(f"Layer '{label}' has Reference '{reference}' which is ambiguous - matches both a Dielectric and a Layer")
+        elif not dielectric_match and not layer_match:
+          errors.append(f"Layer '{label}' has Reference '{reference}' which matches no Dielectric or Layer")
+
+        reference_edge = el.get("ReferenceEdge")
+        if reference_edge is not None and reference_edge != "" and reference_edge.upper() not in ("TOP", "BOTTOM"):
+          errors.append(f"Layer '{label}' has invalid ReferenceEdge '{reference_edge}' (must be Top or Bottom)")
+
+    # circular Layer -> Layer Reference check (Dielectric targets are excluded: a Dielectric
+    # can't reference a Layer, so it can never be part of a cycle)
+    layer_reference_target = {}
+    for el in layer_elements:
+      name = el.get("Name")
+      reference = el.get("Reference")
+      if name and reference and reference in layer_names:
+        layer_reference_target[name] = reference
+
+    resolved_names = set(layer_names) - set(layer_reference_target.keys())
+    remaining = dict(layer_reference_target)
+    progress = True
+    while progress and remaining:
+      progress = False
+      for name, target in list(remaining.items()):
+        if target in resolved_names:
+          resolved_names.add(name)
+          del remaining[name]
+          progress = True
+    if remaining:
+      errors.append(f"Circular Layer Reference detected among: {sorted(remaining.keys())}")
+
+    # Reference-based positioning and <Substrate Offset> are mutually exclusive (see
+    # XML_stackup_format.md) - Offset applying before/after reference resolution is ambiguous
+    substrate_offset_el = get_substrate_offset_element(root)
+    if substrate_offset_el is not None:
+      offset_value = substrate_offset_el.get("Offset")
+      if offset_value is not None and _is_float(offset_value) and float(offset_value) != 0:
+        referenced_layer_names = [el.get("Name") or "<unnamed layer>" for el in layer_elements if el.get("Reference")]
+        if referenced_layer_names:
+          errors.append(f"<Substrate Offset=\"{offset_value}\"> cannot be combined with Reference-based Layer "
+                         f"positioning. Layers using Reference: {referenced_layer_names}")
+
+  # DerivedLayers: these checks intentionally mirror util_stackup_reader.derived_layer's
+  # requirements exactly (invalid Operation / wrong operand count for SIZE / fewer than
+  # 2 operands otherwise / SIZE without a non-zero Oversize) - that reader class calls
+  # exit(1) on any of them instead of raising, which would otherwise kill the whole GUI
+  # process the moment something tries to parse this data (e.g. the live preview).
+  derived_layers_el = get_derived_layers_element(root)
+  derived_names = []
+  if derived_layers_el is not None:
+    all_derived_elements = derived_layers_el.findall("DerivedLayer")
+
+    # a derived layer used as another derived layer's Operand is a pure
+    # intermediate helper (e.g. a poly/implant/contact intersection stage) and
+    # is never itself drawn, so it legitimately doesn't need a <Layer> entry -
+    # only require one for a derived layer nothing else consumes
+    referenced_as_operand = set()
+    for el in all_derived_elements:
+      for operand in el.findall("Operand"):
+        operand_layer = operand.get("Layer")
+        if operand_layer is not None and _is_int(operand_layer):
+          referenced_as_operand.add(int(operand_layer))
+
+    for el in all_derived_elements:
+      name = el.get("Name")
+      layernum = el.get("Layer")
+      operation = el.get("Operation")
+      oversize = el.get("Oversize")
+      operands = [operand.get("Layer") for operand in el.findall("Operand")]
+      label = name or "<unnamed derived layer>"
+
+      if not name:
+        errors.append("DerivedLayer is missing required attribute 'Name'")
+      elif name in derived_names:
+        errors.append(f"Duplicate derived layer Name '{name}'")
+      else:
+        derived_names.append(name)
+
+      if not layernum:
+        errors.append(f"DerivedLayer '{label}' is missing required attribute 'Layer'")
+      elif not _is_int(layernum):
+        errors.append(f"DerivedLayer '{label}' has non-integer Layer='{layernum}'")
+      elif int(layernum) not in layer_numbers and int(layernum) not in referenced_as_operand:
+        errors.append(f"DerivedLayer '{label}' target Layer={layernum} has no matching <Layer> "
+                       f"entry (needed to give it a Z-position/material) and isn't used as "
+                       f"another derived layer's operand either")
+
+      op_upper = operation.upper() if operation else None
+      if not operation:
+        errors.append(f"DerivedLayer '{label}' is missing required attribute 'Operation'")
+      elif op_upper not in VALID_DERIVED_OPERATIONS:
+        errors.append(f"DerivedLayer '{label}' has invalid Operation '{operation}' "
+                       f"(must be one of {VALID_DERIVED_OPERATIONS})")
+
+      oversize_value = None
+      if oversize is not None and oversize != "":
+        if not _is_float(oversize):
+          errors.append(f"DerivedLayer '{label}' has non-numeric Oversize='{oversize}'")
+        else:
+          oversize_value = float(oversize)
+
+      for operand_layer in operands:
+        if not operand_layer or not _is_int(operand_layer):
+          errors.append(f"DerivedLayer '{label}' has a non-integer Operand Layer='{operand_layer}'")
+
+      if op_upper == "SIZE":
+        if len(operands) != 1:
+          errors.append(f"DerivedLayer '{label}' has Operation=\"SIZE\", which needs "
+                         f"exactly 1 operand, found {len(operands)}")
+        if not oversize_value:
+          errors.append(f"DerivedLayer '{label}' has Operation=\"SIZE\", which needs "
+                         f"a non-zero Oversize value")
+      elif op_upper in ("AND", "OR", "XOR", "NOT"):
+        if len(operands) < 2:
+          errors.append(f"DerivedLayer '{label}' needs at least 2 Operand entries, "
+                         f"found {len(operands)}")
+
+  return errors


### PR DESCRIPTION
## Summary
- Move the stackup writer from gds2palace into setupEM (its only real consumer), removing a fragile cross-repo version-skew dependency
- Add File > Import for ADS Momentum stackup files: `*.subst` + `materials.matdb` and self-contained `*.ltd`
- Parse `.ltd` `BEGIN_DERIVEDMASK` boolean mask layers (AND/OR/XOR/NOT), resolving operands by mask name or GDS layer number, verified against two independently-exported real GPDK `.ltd` samples that produce identical DerivedLayers output despite different source syntax
- Fix `.ltd` material classification: `RESISTANCE=` materials with real 3D thickness (INTRUDE/EXPAND) were being collapsed to zero-thickness sheet resistors; classification is now deferred until layer usage is known
- Recognize `EXPAND` as a thickness operation (previously only `INTRUDE` was handled), which would have silently dropped metal layers in some real-world exports
- Add "Convert to legacy format" to the Tools menu, converting Reference-based positions back to absolute Zmin/Zmax or implicit thickness+order for schemaVersion 2.0 compatibility
- Fix a floating-point boundary bug in `register_metals_inside()` that could misassign a metal to the wrong dielectric when two independently-accumulated z values represented the same physical boundary
- Fix an `OverflowError` in the stackup preview caused by unstable cubic spline extrapolation

## Test plan
- [x] Round-tripped all existing reference stackup XML files through validate/save/reparse with no regressions
- [x] Imported real `.subst`+`materials.matdb` and `.ltd` samples (IHP SG13, SBC18 with negative-thickness layers, SG25H5EPIC with suffix stripping, two independent GPDK `.ltd` exports with derived masks) — all pass `validate_stackup()` with zero errors
- [x] Confirmed both GPDK `.ltd` variants (name-based vs. GDS-layer-number-based mask operands) produce identical DerivedLayers output
- [x] Exercised the new import menu actions and legacy-format conversion end-to-end in the Stackup Editor (headless Qt harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)