### PR TITLE
Fix Show Stackup override preview; dependency sync; add reference stackup XML

### DIFF
--- a/src/setupEM/data/SG13G2_200um_with_parameters.xml
+++ b/src/setupEM/data/SG13G2_200um_with_parameters.xml
@@ -1,0 +1,106 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Stackup schemaVersion="3.1">
+  <!-- Created/modified using the XML Stackup Editor in Stackup Editor -->
+  <!-- ============================================================ -->
+  <!-- Model for use with gds2palace S-Parameter simulation: -->
+  <!-- IHP SG13G2 with Resistors Rsil, Rppd and Rhigh included using derived layers.  -->
+  <!-- Substrate height defined using variable "total_thickness", default to 200 um final chip height (including BEOL). -->
+  <!-- Air above defined using variable "air_thickness", default to 200 um. -->
+  <!--  -->
+  <!-- Do not use with openEMS flow, the thin MIM dielectric will cause a tiny timestep = long simulation time.  -->
+  <!-- MIM is modelled differently for openEMS stackups, with an equivalent dielectric that has same C per area, but without that tiny gap. -->
+  <!-- ============================================================ -->
+  <!-- Reference-relative positioning requires gds2palace util_stackup_reader.py version 1.6.0 or newer -->
+  <!-- <Variables>/"="-expressions require gds2palace util_stackup_reader.py version 1.7.0 or newer -->
+  <Variables>
+    <Variable Name="air_thickness" Value="200.0000" />
+    <Variable Name="total_thickness" Value="200.0000" />
+    <Variable Name="bulk_thickness" Value="=total_thickness-20" />
+  </Variables>
+  <Materials>
+    <Material Name="Activ" Type="Conductor" Conductivity="357141.0" Color="00ff00" />
+    <Material Name="Metal1" Type="Conductor" Conductivity="21640000.0" Color="39bfff" />
+    <Material Name="Metal2" Type="Conductor" Conductivity="23190000.0" Color="ccccd9" />
+    <Material Name="Metal3" Type="Conductor" Conductivity="23190000.0" Color="d80000" />
+    <Material Name="Metal4" Type="Conductor" Conductivity="23190000.0" Color="93e837" />
+    <Material Name="Metal5" Type="Conductor" Conductivity="23190000.0" Color="dcd146" />
+    <Material Name="TopMetal1" Type="Conductor" Conductivity="27800000.0" Color="ffe6bf" />
+    <Material Name="TopMetal2" Type="Conductor" Conductivity="30300000.0" Color="ff8000" />
+    <Material Name="TopVia2" Type="Conductor" Conductivity="3143000.0" Color="ff8000" />
+    <Material Name="TopVia1" Type="Conductor" Conductivity="2191000.0" Color="ffe6bf" />
+    <Material Name="Via4" Type="Conductor" Conductivity="1660000.0" Color="deac5e" />
+    <Material Name="Via3" Type="Conductor" Conductivity="1660000.0" Color="9ba940" />
+    <Material Name="Via2" Type="Conductor" Conductivity="1660000.0" Color="ff3736" />
+    <Material Name="Via1" Type="Conductor" Conductivity="1660000.0" Color="ccccff" />
+    <Material Name="Cont" Type="Conductor" Conductivity="2390000.0" Color="00ffff" />
+    <Material Name="Passive" Type="Dielectric" Permittivity="6.6" DielectricLossTangent="0.0" Color="a0a0f0" />
+    <Material Name="SiO2" Type="Dielectric" Permittivity="4.1" DielectricLossTangent="0.0" Color="fffcad" />
+    <Material Name="Substrate" Type="Semiconductor" Permittivity="11.9" DielectricLossTangent="0" Conductivity="2.0" Color="01e0ff" />
+    <Material Name="EPI" Type="Semiconductor" Permittivity="11.9" DielectricLossTangent="0" Conductivity="5.0" Color="294fff" />
+    <Material Name="AIR" Type="Dielectric" Permittivity="1.0" DielectricLossTangent="0.0" Color="d0d0d0" />
+    <Material Name="Vmim" Type="Conductor" Conductivity="2191000.0" Color="ffe6bf" />
+    <Material Name="MIM" Type="Conductor" Conductivity="500000.0" Color="e6ffbf" />
+    <Material Name="LOWLOSS" Type="Conductor" Conductivity="1E10" Color="ff0000" />
+    <Material Name="RSIL" Type="Resistor" Rs="7" Color="d0d0d0" />
+    <Material Name="RPPD" Type="Resistor" Rs="260" Color="d0d0d0" />
+    <Material Name="RHIGH" Type="Resistor" Rs="1360" Color="d0d0d0" />
+  </Materials>
+  <ELayers LengthUnit="um">
+    <Dielectrics>
+      <Dielectric Name="AIR" Reference="Passive" ReferenceEdge="Top" Material="AIR" Thickness="=air_thickness" />
+      <Dielectric Name="Passive" Reference="SiO2" ReferenceEdge="Top" Material="Passive" Thickness="0.4000" />
+      <Dielectric Name="SiO2" Reference="EPI" ReferenceEdge="Top" Material="SiO2" Thickness="15.7303" />
+      <Dielectric Name="EPI" Reference="Substrate" ReferenceEdge="Top" Material="EPI" Thickness="3.7500" />
+      <Dielectric Name="Substrate" Material="Substrate" Thickness="=bulk_thickness" />
+    </Dielectrics>
+    <Layers>
+      <!-- SG13G2 resistors created from derived layers defined in DerivedLayers section below-->
+      <Layer Name="TopMetal2" Type="conductor" Reference="TopVia2" ReferenceEdge="Top" Material="TopMetal2" Layer="134" Zmin="0.0000" Zmax="3.0000" />
+      <Layer Name="TopVia2" Type="via" Reference="TopMetal1" ReferenceEdge="Top" Material="TopVia2" Layer="133" Zmin="0.0000" Zmax="2.8000" />
+      <Layer Name="TopMetal1" Type="conductor" Reference="TopVia1" ReferenceEdge="Top" Material="TopMetal1" Layer="126" Zmin="0.0000" Zmax="2.0000" />
+      <Layer Name="Vmim" Type="via" Reference="MIM" ReferenceEdge="Top" Material="Vmim" Layer="129" Zmin="0.0000" Zmax="0.6763" />
+      <Layer Name="MIM" Type="conductor" Reference="Metal5" ReferenceEdge="Top" Material="MIM" Layer="36" Zmin="0.0243" Zmax="0.1740" />
+      <Layer Name="TopVia1" Type="via" Reference="Metal5" ReferenceEdge="Top" Material="TopVia1" Layer="125" Zmin="0.0000" Zmax="0.8503" />
+      <Layer Name="Metal5" Type="conductor" Reference="Via4" ReferenceEdge="Top" Material="Metal5" Layer="67" Zmin="0.0000" Zmax="0.4900" />
+      <Layer Name="Via4" Type="via" Reference="Metal4" ReferenceEdge="Top" Material="Via4" Layer="66" Zmin="0.0000" Zmax="0.5400" />
+      <Layer Name="Metal4" Type="conductor" Reference="Via3" ReferenceEdge="Top" Material="Metal4" Layer="50" Zmin="0.0000" Zmax="0.4900" />
+      <Layer Name="Via3" Type="via" Reference="Metal3" ReferenceEdge="Top" Material="Via3" Layer="49" Zmin="0.0000" Zmax="0.5400" />
+      <Layer Name="Metal3" Type="conductor" Reference="Via2" ReferenceEdge="Top" Material="Metal3" Layer="30" Zmin="0.0000" Zmax="0.4900" />
+      <Layer Name="Via2" Type="via" Reference="Metal2" ReferenceEdge="Top" Material="Via2" Layer="29" Zmin="0.0000" Zmax="0.5400" />
+      <Layer Name="Metal2" Type="conductor" Reference="Via1" ReferenceEdge="Top" Material="Metal2" Layer="10" Zmin="0.0000" Zmax="0.4900" />
+      <Layer Name="Via1" Type="via" Reference="Metal1" ReferenceEdge="Top" Material="Via1" Layer="19" Zmin="0.0000" Zmax="0.5400" />
+      <Layer Name="Metal1" Type="conductor" Reference="Cont" ReferenceEdge="Top" Material="Metal1" Layer="8" Zmin="0.0000" Zmax="0.4200" />
+      <Layer Name="Cont" Type="via" Reference="Activ" ReferenceEdge="Top" Material="Cont" Layer="6" Zmin="0.0000" Zmax="0.6400" />
+      <Layer Name="RHIGH" Type="sheet" Reference="Activ" ReferenceEdge="Top" Material="RHIGH" Layer="312" Zmin="0.0000" Zmax="0.0000" />
+      <Layer Name="RPPD" Type="sheet" Reference="Activ" ReferenceEdge="Top" Material="RPPD" Layer="313" Zmin="0.0000" Zmax="0.0000" />
+      <Layer Name="RSIL" Type="sheet" Reference="Activ" ReferenceEdge="Top" Material="RSIL" Layer="314" Zmin="0.0000" Zmax="0.0000" />
+      <Layer Name="Activ" Type="conductor" Reference="SiO2" ReferenceEdge="Bottom" Material="Activ" Layer="1" Zmin="0.0000" Zmax="0.4000" />
+      <Layer Name="SUBGND" Type="conductor" Reference="EPI" ReferenceEdge="Bottom" Material="LOWLOSS" Layer="250" Zmin="0.0000" Zmax="3.7500" />
+      <Layer Name="LBE" Type="dielectric" Reference="Substrate" ReferenceEdge="Bottom" Material="AIR" Layer="157" Zmin="0.0000" Zmax="=bulk_thickness + 3.7500" />
+      <Layer Name="BACKSIDEGND" Type="conductor" Reference="Substrate" ReferenceEdge="Bottom" Material="LOWLOSS" Layer="251" Zmin="-6.2500" Zmax="0.0000" />
+    </Layers>
+    <DerivedLayers>
+      <DerivedLayer Name="GatPoly" Layer="310" Operation="OR">
+        <Operand Layer="5" />
+        <Operand Layer="128" />
+      </DerivedLayer>
+      <DerivedLayer Name="Rhigh_or_Rppd" Layer="311" Operation="AND">
+        <Operand Layer="28" />
+        <Operand Layer="14" />
+        <Operand Layer="310" />
+      </DerivedLayer>
+      <DerivedLayer Name="RHIGH" Layer="312" Operation="AND">
+        <Operand Layer="311" />
+        <Operand Layer="7" />
+      </DerivedLayer>
+      <DerivedLayer Name="RPPD" Layer="313" Operation="NOT">
+        <Operand Layer="311" />
+        <Operand Layer="7" />
+      </DerivedLayer>
+      <DerivedLayer Name="RSIL" Layer="314" Operation="NOT">
+        <Operand Layer="310" />
+        <Operand Layer="311" />
+      </DerivedLayer>
+    </DerivedLayers>
+  </ELayers>
+</Stackup>

--- a/src/setupEM/setup_common.py
+++ b/src/setupEM/setup_common.py
@@ -370,7 +370,7 @@ class FileInputTab(QWidget):
         self.XML_show_layout.setAlignment(Qt.AlignRight)
         self.show_XML_btn = QPushButton("Show Stackup")
         self.show_XML_btn.setFixedWidth(150)
-        self.show_XML_btn.clicked.connect(self.MainWindow.open_popup)
+        self.show_XML_btn.clicked.connect(self.show_stackup)
         self.XML_show_layout.addWidget(self.show_XML_btn)
         self.XML_layout.addLayout(self.XML_show_layout)
 
@@ -661,6 +661,15 @@ class FileInputTab(QWidget):
         self.MainWindow.read_XML()
 
         return True  # Tab change only possible when returning True
+
+    def show_stackup(self):
+        # "Show Stackup" is a plain button click, not a tab change, so nothing
+        # would otherwise flush the override grid into saved_values/materials_list
+        # before the popup reads them - save first so edited overrides not yet
+        # committed by switching tabs still show up in the preview.
+        if not self.save_values():
+            return
+        self.MainWindow.open_popup()
 
 
 # ---- Python Syntax Highlighter ----
@@ -1815,7 +1824,8 @@ class MainWindowBase(QMainWindow):
     def read_XML(self):
         filename = self.saved_values["SubstrateFile"]
         if pathlib.Path(filename).exists():
-            self.materials_list, self.dielectrics_list, self.metals_list = stackup_reader.read_substrate(filename)
+            self.materials_list, self.dielectrics_list, self.metals_list = stackup_reader.read_substrate(
+                filename, variable_overrides=self.saved_values.get("variable_overrides"))
             self.update_target_layer_choices(self.metals_list)
             self.file_tab.update_XML_description(filename)
             self.file_tab.update_variable_overrides_grid(filename)


### PR DESCRIPTION
## Summary
- Fix "Show Stackup" popup ignoring the Input Files tab's variable-override grid: `read_XML()` now forwards `variable_overrides` into `stackup_reader.read_substrate()`, and the button now saves the tab (flushing the override grid) before opening the preview, since a plain button click never triggered that flush.
- Add `SG13G2_200um_with_parameters.xml`, a reference stackup using `total_thickness`/`air_thickness` Variables and a `bulk_thickness` expression, for exercising the override grid.
- Sync declared/documented dependencies with actual imports (carried over from a prior commit on this branch).

## Test plan
- [x] Launch `setupEM`, open the Input Files tab, load `SG13G2_200um_with_parameters.xml`, edit an override value (e.g. `total_thickness`), click "Show Stackup", and confirm the preview reflects the overridden value.
- [x] Confirm "Preview model geometry in gmsh" and an actual simulation run still apply overrides correctly (unaffected, pre-existing behavior).