### PR TITLE
License fix, PyPI packaging, Stackup Editor features, and Windows/WSL simulation improvements

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,4 +1,4 @@
-# What's New - August 19, 2026
+# What's New - August 21, 2026
 
 Changes since the version from about 3 months ago, focused on features that matter to end users. For general usage, see the main [README](../README.md).
 
@@ -51,3 +51,11 @@ Points don't need to be entered in temperature order - they're sorted automatica
 ## License correction
 
 Corrected a license inconsistency: the repository's LICENSE file said Apache-2.0, while every source file's own header comment already said GPLv3. The code headers were correct - setupEM imports gds2palace's Python API directly in-process, and gds2palace is itself GPLv3, so GPLv3 is the license actually required here. LICENSE, `pyproject.toml`, and the two files that had no header now all agree on GPLv3.
+
+## Faster, more informative Palace runs on Windows
+
+**Start Simulation** on Windows no longer opens a separate WSL terminal window and waits for you to type `./run_sim` yourself. It now runs `./run_sim` directly inside WSL and streams Palace's console output live into the Log panel, exactly like the existing Linux behavior - no terminal window appears at all. This also means **Terminate** now actually stops a running Windows/WSL simulation, and the Log panel accurately reflects when the run has really finished (previously the terminal launcher returned almost immediately, long before Palace itself was done). This still only works for simulation directories on a local drive - WSL cannot reach a network drive.
+
+When a Palace simulation finishes, a **results summary** is now appended to the Log panel automatically: degrees of freedom, mesh element count, simulation time, peak RAM, and the mesh-adaptation error indicators (Norm/Max/Mean), read directly from Palace's own `palace.json` and `error-indicators.csv` output files. For a run using adaptive mesh refinement, this is a table with one row per refinement iteration plus the final converged result, so you can see how DOF and error indicators evolved across iterations at a glance.
+
+The Log panel also now uses a monospaced font (Consolas on Windows, Ubuntu Mono/DejaVu Sans Mono on Linux), so solver output and the results table line up in neat columns instead of a proportional font.

--- a/doc/setupEM_userguide.md
+++ b/doc/setupEM_userguide.md
@@ -1,6 +1,6 @@
 # setupEM and setupThermal User's Guide
 
-Document version: 2026-08-19
+Document version: 2026-08-21
 
 ## Contents
 [What's New](#whats-new)  
@@ -49,6 +49,7 @@ This chapter gives a brief overview of major features added since the previous e
 - **A graphical Stackup XML Editor**, reachable from **Tools > Edit Stackup XML...** in both apps — see chapter "[The Stackup Editor](#the-stackup-editor)". It replaces hand-editing the stackup XML in a text editor, and covers Materials, Dielectric Stack, drawn and Derived Layers, Variables/expressions, and Thermal Tables.
 - **setupThermal**, a companion app for building Elmer thermal simulation models the same guided way as setupEM builds Palace/Elmer EM models — see chapter "[setupThermal](#setupthermal)".
 - **Overriding stackup Variables from the Input Files tab.** If the chosen XML file declares `<Variable>`s (e.g. `total_thickness`, `air_thickness`), an editable grid now lets you override their values for this run, without touching the XML file or the generated script — see "[File description and overriding stackup Variables](#file-description-and-overriding-stackup-variables)".
+- **Start Simulation on Windows runs Palace directly and shows results automatically.** No more opening a terminal and typing `./run_sim` yourself - output streams live into the Log panel, Terminate actually works, and a results summary (degrees of freedom, simulation time, peak RAM, mesh-adaptation error indicators) appears automatically once a run finishes - see "[Create Model tab](#create-model-tab)".
 
 
 ## About setupEM and setupThermal
@@ -207,13 +208,15 @@ The buttons work top-down: **preview** the model geometry first, then **create t
 
 <img src="./png/createmodel2.png" alt="create" width="700">
 
-**Start Simulation** runs the solver: on Linux this starts Palace via script `run_sim`; on Windows it opens the Windows Subsystem for Linux (WSL) in the simulation directory.
+**Start Simulation** runs the solver: on Linux this starts Palace via script `run_sim` directly; on Windows it runs the same `run_sim` script inside the Windows Subsystem for Linux (WSL), automatically - no terminal window opens, and Palace's console output streams live into the Log panel below, the same as on Linux. This works for simulation directories on a LOCAL drive only - WSL cannot reach a network drive. **Terminate** stops a running simulation, including one running inside WSL on Windows.
 
 <img src="./png/createmodel3.png" alt="create" width="700">
 
-On Linux, this needs a `run_sim` script configured as described in the [gds2palace documentation](https://github.com/VolkerMuehlhaus/gds2palace_ihp_sg13g2/blob/main/doc/gds2palace_workflow_userguide.pdf) (template in that repository's `scripts` directory). On Windows/WSL, type `./run_sim` in the opened terminal.
+This needs a `run_sim` script configured as described in the [gds2palace documentation](https://github.com/VolkerMuehlhaus/gds2palace_ihp_sg13g2/blob/main/doc/gds2palace_workflow_userguide.pdf) (template in that repository's `scripts` directory); on Windows, the same requirement applies inside your WSL environment, e.g. `run_palace` needs to be reachable there via `PATH` (usually set up in `~/.profile`).
 
-To convert simulation results to Touchstone SnP format, use script `combine_snp` (see the `scripts` directory) - it scans your working directory and below, and supports both Palace and Elmer S-parameter output.
+When a Palace simulation finishes, a **results summary** is appended to the Log panel automatically: degrees of freedom, mesh elements, simulation time, peak RAM, and the mesh-adaptation error indicators (Norm/Max/Mean), read from Palace's own `palace.json`/`error-indicators.csv` output. For a run using adaptive mesh refinement, this is a table with one row per refinement iteration.
+
+To convert simulation results to Touchstone SnP format, use script `combine_snp` (see the `scripts` directory) - it scans your working directory and below, and supports both Palace and Elmer S-parameter output. This already runs automatically as the last step of `run_sim`.
 
 ## Code tab
 

--- a/src/setupEM/palace_results.py
+++ b/src/setupEM/palace_results.py
@@ -1,0 +1,199 @@
+########################################################################
+#
+# Copyright 2025 Volker Muehlhaus and IHP PDK Authors
+#
+# Licensed under the GNU General Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+########################################################################
+
+"""Parse AWS Palace solver output (palace.json / error-indicators.csv) into a
+human-readable summary for the setupEM "Create Model" log. No Qt dependency,
+so this can be exercised standalone against real Palace output directories.
+"""
+
+import os
+import json
+import csv
+import re
+
+_ITERATION_RE = re.compile(r'^iteration(\d+)$')
+
+
+def _find_output_dir(run_path, model_basename):
+    # config.json's Problem.Output is a path relative to config.json's own directory
+    config_path = os.path.join(run_path, 'config.json')
+    output_rel = None
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+            output_rel = config.get('Problem', {}).get('Output')
+        except (OSError, json.JSONDecodeError):
+            output_rel = None
+    if not output_rel:
+        output_rel = 'output/' + model_basename
+    return os.path.normpath(os.path.join(run_path, output_rel))
+
+
+def _read_palace_json(dir_path):
+    path = os.path.join(dir_path, 'palace.json')
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    return {
+        'duration_s': data.get('ElapsedTime', {}).get('Durations', {}).get('Total'),
+        'peak_ram_mb': data.get('PeakMemoryMegabytes', {}).get('Total'),
+        'dof': data.get('Problem', {}).get('DegreesOfFreedom'),
+        'mesh_elements': data.get('Problem', {}).get('MeshElements'),
+    }
+
+
+def _read_error_indicators(dir_path):
+    path = os.path.join(dir_path, 'error-indicators.csv')
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, 'r', encoding='utf-8', newline='') as f:
+            rows = [row for row in csv.reader(f, skipinitialspace=True) if row]
+    except OSError:
+        return None
+    if len(rows) < 2:
+        return None
+    headers = [h.strip() for h in rows[0]]
+    values = [v.strip() for v in rows[1]]
+    fields = dict(zip(headers, values))
+    try:
+        return {
+            'norm': float(fields['Norm']),
+            'minimum': float(fields['Minimum']),
+            'maximum': float(fields['Maximum']),
+            'mean': float(fields['Mean']),
+        }
+    except (KeyError, ValueError):
+        return None
+
+
+def _list_iteration_dirs(output_dir):
+    if not os.path.isdir(output_dir):
+        return []
+    found = []
+    for name in os.listdir(output_dir):
+        match = _ITERATION_RE.match(name)
+        full_path = os.path.join(output_dir, name)
+        if match and os.path.isdir(full_path):
+            found.append((int(match.group(1)), full_path))
+    found.sort(key=lambda item: item[0])
+    return [full_path for _, full_path in found]
+
+
+def _format_duration(seconds):
+    if seconds is None:
+        return 'n/a'
+    if seconds < 60:
+        return f"{seconds:.1f} s"
+    minutes, secs = divmod(int(round(seconds)), 60)
+    hours, minutes = divmod(minutes, 60)
+    if hours:
+        return f"{hours}h {minutes}m {secs}s"
+    return f"{minutes}m {secs}s"
+
+
+def _format_ram(mb):
+    if mb is None:
+        return 'n/a'
+    if mb >= 1024:
+        return f"{mb / 1024:.2f} GB"
+    return f"{mb:.1f} MB"
+
+
+def _format_int(n):
+    return 'n/a' if n is None else f"{n:,}"
+
+
+def _format_sci(x):
+    return 'n/a' if x is None else f"{x:.3e}"
+
+
+def build_results_summary(run_path, model_basename):
+    """Return a formatted multi-line summary of Palace results found under run_path,
+    or an explanatory message if nothing is there yet.
+    """
+    output_dir = _find_output_dir(run_path, model_basename)
+    if not os.path.isdir(output_dir):
+        return (f"No Palace results found yet (expected output directory: {output_dir}) "
+                 "-- has the simulation finished?")
+
+    iteration_dirs = _list_iteration_dirs(output_dir)
+
+    if not iteration_dirs:
+        summary = _read_palace_json(output_dir)
+        errors = _read_error_indicators(output_dir)
+        if summary is None:
+            return (f"No palace.json found yet in {output_dir} "
+                     "-- has the simulation finished?")
+        lines = [
+            f"=== Simulation results: {model_basename} ===",
+            f"Degrees of freedom : {_format_int(summary['dof'])}",
+            f"Mesh elements      : {_format_int(summary['mesh_elements'])}",
+            f"Simulation time    : {_format_duration(summary['duration_s'])}",
+            f"Peak RAM           : {_format_ram(summary['peak_ram_mb'])}",
+        ]
+        if errors:
+            lines.append(
+                f"Error indicator    : Norm={_format_sci(errors['norm'])}  "
+                f"Max={_format_sci(errors['maximum'])}  Mean={_format_sci(errors['mean'])}"
+            )
+        lines.append("=" * 40)
+        return "\n".join(lines)
+
+    # Adaptive mesh refinement: one row per iteration subfolder, plus the root as "Final"
+    rows = [(os.path.basename(it_dir), _read_palace_json(it_dir), _read_error_indicators(it_dir))
+            for it_dir in iteration_dirs]
+    rows.append(("Final", _read_palace_json(output_dir), _read_error_indicators(output_dir)))
+
+    headers = ["Iteration", "DOF", "Mesh elems", "Error Norm", "Error Max", "Error Mean", "Time", "Peak RAM"]
+    table_rows = []
+    for label, summary, errors in rows:
+        summary = summary or {}
+        errors = errors or {}
+        table_rows.append([
+            label,
+            _format_int(summary.get('dof')),
+            _format_int(summary.get('mesh_elements')),
+            _format_sci(errors.get('norm')),
+            _format_sci(errors.get('maximum')),
+            _format_sci(errors.get('mean')),
+            _format_duration(summary.get('duration_s')),
+            _format_ram(summary.get('peak_ram_mb')),
+        ])
+
+    widths = [max(len(headers[i]), *(len(r[i]) for r in table_rows)) for i in range(len(headers))]
+
+    def fmt_row(cells):
+        return " | ".join(
+            cell.ljust(widths[i]) if i == 0 else cell.rjust(widths[i])
+            for i, cell in enumerate(cells)
+        )
+
+    lines = [f"=== Simulation results: {model_basename} (adaptive mesh refinement) ==="]
+    header_line = fmt_row(headers)
+    lines.append(header_line)
+    lines.append("-+-".join("-" * w for w in widths))
+    for row in table_rows:
+        lines.append(fmt_row(row))
+    lines.append("=" * len(header_line))
+    return "\n".join(lines)

--- a/src/setupEM/setupEM.py
+++ b/src/setupEM/setupEM.py
@@ -54,6 +54,7 @@ if __package__ in (None, ""):
         VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
         epsilon_to_color, default_stackup_dielectric_label, default_stackup_metal_label,
     )
+    from palace_results import build_results_summary
 else:
     from .setup_common import (
         EDIT_STYLE_OPTIONAL, EDIT_STYLE_REQUIRED, COMBO_STYLE_REQUIRED, COMBO_STYLE_OPTIONAL,
@@ -61,6 +62,7 @@ else:
         VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
         epsilon_to_color, default_stackup_dielectric_label, default_stackup_metal_label,
     )
+    from .palace_results import build_results_summary
 
 
 '''
@@ -1079,6 +1081,26 @@ class CreateModelTab(CreateModelTabBase):
     are specific to this app.
     """
 
+    def __init__(self, MainWindow):
+        super().__init__(MainWindow)
+
+        # Tracks which action self.process is currently running, so on_finished() can tell a
+        # simulation run apart from a mesh-creation run (self.process is reused for both).
+        self._process_purpose = None
+
+    def _append_results_summary(self):
+        # Palace-only: parse palace.json / error-indicators.csv and append a results summary
+        # to the log. Called from on_finished() after a real simulation run.
+        run_path = saved_values['sim_path'] + "/palace_model/" + saved_values['model_basename'] + "_data"
+        summary = build_results_summary(run_path, saved_values['model_basename'])
+        self.log_area.appendPlainText("\n" + summary + "\n")
+
+    def on_finished(self, exit_code, exit_status):
+        super().on_finished(exit_code, exit_status)
+        # Auto-append the results summary after a real simulation run (not after mesh creation)
+        if self._process_purpose == "run_simulation" and self.MainWindow.PalaceMode:
+            self._append_results_summary()
+
     def create_model(self):
         # Request all tabs to save values again,
         # which can do some update to saved_values
@@ -1105,6 +1127,7 @@ class CreateModelTab(CreateModelTabBase):
 
             # Run Python interpreter on that file
             python_exe = sys.executable  # Use the same Python interpreter
+            self._process_purpose = "create_mesh"
             self.process.start(python_exe, [pymodel_filename])
 
 
@@ -1118,6 +1141,7 @@ class CreateModelTab(CreateModelTabBase):
 
         # clear log
         self.log_area.clear()
+        self._process_purpose = "run_simulation"
 
         if self.MainWindow.PalaceMode:
             self.log_area.appendPlainText("Trying to start Palace using script ./run_sim now")
@@ -1143,10 +1167,21 @@ class CreateModelTab(CreateModelTabBase):
 
 
                 wsl_run_path = windows_to_wsl_path(run_path)
-                # tell user what to do, we can open WSL in the right place but not start simulation
-                self.log_area.appendPlainText("Running on Windows with WSL, you need to type ./run_sim in the terminal yourself!")
-                self.log_area.appendPlainText("Note that this works for LOCAL drives only, we can't open WSL on network drive.")
-                self.process.start("cmd.exe", ["/c", "start", "wt.exe", "wsl", "--cd", wsl_run_path])
+                self.log_area.appendPlainText("Running on Windows with WSL: starting ./run_sim ...")
+                self.log_area.appendPlainText("Note that this works for LOCAL drives only, we can't open WSL on network drive.\n")
+                # Run wsl.exe directly as self.process (no terminal emulator in between), so Palace's
+                # stdout/stderr stream into this log via the existing on_stdout/on_stderr handlers, and
+                # on_finished fires with the real exit code when ./run_sim actually completes -- instead
+                # of opening a detached terminal window, whose own quoting/tokenization rules (cmd's
+                # "start", and wt.exe's own use of ";" as a pane/command separator) make embedding a
+                # multi-step shell command fragile, and whose completion can't be tracked anyway.
+                # bash -lc: login shell so ~/.profile (where PATH additions for run_palace/combine_snp
+                # usually live, per gds2palace's scripts/README.md) gets sourced, same as a manually
+                # typed ./run_sim in a fresh WSL login shell would.
+                self.process.start("wsl.exe", [
+                    "--cd", wsl_run_path,
+                    "--", "bash", "-lc", "./run_sim"
+                ])
             else:
                 # Linux
                 self.log_area.appendPlainText('Setting work directory ' + run_path)

--- a/src/setupEM/setup_common.py
+++ b/src/setupEM/setup_common.py
@@ -1246,6 +1246,16 @@ class CreateModelTabBase(QWidget):
         self.log_group.setLayout(self.log_layout)
         self.log_area = QPlainTextEdit()
         self.log_area.setReadOnly(True)
+        log_font = QFont()
+        # Consolas/Cascadia Mono: Windows. Ubuntu Mono: default on Ubuntu (this app's primary
+        # Linux target, see the Ubuntu 24.04 notice below) and narrower than DejaVu Sans Mono.
+        # Liberation Mono/DejaVu Sans Mono: broader Linux fallbacks. "monospace": generic
+        # fontconfig alias, guaranteed to resolve to an installed monospace font on Linux.
+        log_font.setFamilies(["Consolas", "Cascadia Mono", "Ubuntu Mono", "Liberation Mono", "DejaVu Sans Mono", "monospace"])
+        log_font.setStyleHint(QFont.Monospace)
+        log_font.setFixedPitch(True)
+        log_font.setPointSize(9)
+        self.log_area.setFont(log_font)
         self.log_layout.addWidget(self.log_area)
 
         self.main_layout.addWidget(self.file_group)


### PR DESCRIPTION
## Summary
- **License correction**: LICENSE file said Apache-2.0 while every source header said GPLv3; LICENSE/pyproject.toml now agree on GPLv3 (required since setupEM imports gds2palace, itself GPLv3).
- **PyPI packaging**: build setupEM for PyPI directly, fix `__version__` drift, add a PyPI-specific README with absolute image URLs.
- **Stackup Editor**: stackup Variable overrides grid (Input Files tab), Thermal Tables editing, undo/XML-preview-refresh fix, and misc polish.
- **Docs**: new `doc/setupEM_userguide.md` (full user's guide with a dedicated Stackup Editor chapter) and updated `CHANGES.md`.
- **Bugfix**: Show Stackup preview was ignoring Input Files tab overrides.
- **Windows/WSL simulation improvements**: Start Simulation on Windows now runs `./run_sim` directly through `wsl.exe` and streams Palace's output live into the Log panel, instead of opening a detached terminal window the user had to type into - Terminate now works on Windows too, and a results summary (degrees of freedom, mesh elements, simulation time, peak RAM, mesh-adaptation error indicators) is parsed from Palace's `palace.json`/`error-indicators.csv` and appended to the log automatically, with a per-iteration table for adaptive mesh refinement runs. The Log panel also switches to a monospaced font.
- Also: dependency sync, an SG13G2 200um stackup with parameters example, and misc `.gitignore`/version bumps.

## Test plan
- [ ] Install from this branch and confirm `setupEM`/`setupThermal` launch correctly
- [ ] Verify the Stackup Editor's new tabs (Variables overrides grid, Thermal Tables) work as documented
- [ ] On Windows, confirm Start Simulation runs Palace via WSL without opening a terminal, streams output live, and the results summary/AMR table appears after a run finishes
- [ ] Confirm LICENSE/pyproject.toml/PyPI metadata are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)