### PR TITLE
Frequencies tab fix, Palace-only N=3 mesh option, and misc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ On this tab, you configure input files:
 
 The fields for GDSII and XML file support drag & drop or you can use the Browse... buttons.
 
-Some pre-processing of the layout is also defined here: You can specify a distance (in micron) which is used for **via array merging**, to speed up simulation by replacing many individual vias with one large via box. If your layout includes **polygons with holes**, you need to set the "Preprocess GDSII file" checkbox, otherwise you will get error messages during meshing.
+Some pre-processing of the layout is also defined here: You can specify a distance (in micron) which is used for **via array merging**, to speed up simulation by replacing many individual vias with one large via box.
 
 <img src="./doc/png/inputfiles1.png" alt="input files" width="700">
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,8 @@
+
+# What's New - August 31, 2026
+
+Added a "slower, most accurate (N=3)" mesh basis function option, available in Palace mode only since Elmer doesn't support it. Fixed the Frequencies tab silently dropping (or reusing stale) `fstart`/`fstop` when left blank.  
+
 # What's New - August 21, 2026
 
 Changes since the version from about 3 months ago, focused on features that matter to end users. For general usage, see the main [README](../README.md).
@@ -58,4 +63,3 @@ Corrected a license inconsistency: the repository's LICENSE file said Apache-2.0
 
 When a Palace simulation finishes, a **results summary** is now appended to the Log panel automatically: degrees of freedom, mesh element count, simulation time, peak RAM, and the mesh-adaptation error indicators (Norm/Max/Mean), read directly from Palace's own `palace.json` and `error-indicators.csv` output files. For a run using adaptive mesh refinement, this is a table with one row per refinement iteration plus the final converged result, so you can see how DOF and error indicators evolved across iterations at a glance.
 
-The Log panel also now uses a monospaced font (Consolas on Windows, Ubuntu Mono/DejaVu Sans Mono on Linux), so solver output and the results table line up in neat columns instead of a proportional font.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
     { name = "Volker Muehlhaus", email = "volker@muehlhaus.com" }
 ]
 dependencies = [
-    "gds2palace>=0.3.6",
+    "gds2palace>=0.4.0",
     "PySide6",
     "scipy",
     "requests",

--- a/src/setupEM/__init__.py
+++ b/src/setupEM/__init__.py
@@ -24,4 +24,4 @@ A Python tool for EM setup using gds2palace.
 from .setupEM import main
 
 __all__ = ["main"]
-__version__ = "0.3.15"
+__version__ = "0.3.16"

--- a/src/setupEM/setupEM.py
+++ b/src/setupEM/setupEM.py
@@ -709,7 +709,7 @@ class MeshTab(QWidget):
         self.mesh_order_box = QComboBox()
         self.mesh_order_box.setFixedWidth(edit_width)
         self.mesh_order_box.setStyleSheet(COMBO_STYLE_OPTIONAL)
-        self.mesh_order_box.addItems(["faster, less accurate","most accurate"])
+        self.mesh_order_box.addItems(["faster, less accurate (N=1)","default (N=2)", "slower, ultra accurate (N=3)"])
         self.meshorder_layout.addWidget(self.mesh_order_box)
         self.mesh_order_box.setCurrentIndex(0)
         self.meshorder_layout.addStretch()
@@ -923,6 +923,22 @@ class MeshTab(QWidget):
                 self.solver_box.setDisabled(True)
             else:
                 self.solver_box.setDisabled(False)
+        except:
+            pass
+
+        # order=3 (ultra accurate) is Palace-only: Elmer has no cubic-order solver
+        # templates in util_elmer.write_case_and_solver_files(), so it would silently
+        # fall back to first-order there. Disable that option under Elmer mode, and
+        # fall back to the default order if it was selected when switching into Elmer.
+        try:
+            ultra_accurate_index = 2
+            item = self.mesh_order_box.model().item(ultra_accurate_index)
+            if self.MainWindow.ElmerMode:
+                item.setEnabled(False)
+                if self.mesh_order_box.currentIndex() == ultra_accurate_index:
+                    self.mesh_order_box.setCurrentIndex(1)
+            else:
+                item.setEnabled(True)
         except:
             pass
 

--- a/src/setupEM/setupEM.py
+++ b/src/setupEM/setupEM.py
@@ -181,29 +181,43 @@ class FrequenciesTab(QWidget):
 
 
     def save_values(self):
-        try:
-            fstart = float(self.start_edit.text())
-        except Exception:
-            # the only case when this field can be empty is when fpoint or fdump are defined
-            if self.start_edit.text()=="" and (self.fpoint_edit.text() != "" or self.fdump_edit.text() != ""):
-                return True
+        # fstart/fstop may be left empty only if fpoint or fdump supplies at least
+        # one frequency instead (gds2palace treats fstart/fstop as fully optional)
+        discrete_freqs_given = (self.fpoint_edit.text() != "" or self.fdump_edit.text() != "")
+
+        fstart = None
+        if self.start_edit.text() == "":
+            if discrete_freqs_given:
+                saved_values.pop("fstart", None) # don't leave stale sweep data behind
             else:
                 QMessageBox.warning(self, "Error", "Not a valid value for fstart")
                 self.start_edit.setText("0")
                 return False
-        saved_values ["fstart"] = float(fstart)
+        else:
+            try:
+                fstart = float(self.start_edit.text())
+            except Exception:
+                QMessageBox.warning(self, "Error", "Not a valid value for fstart")
+                self.start_edit.setText("0")
+                return False
+            saved_values ["fstart"] = fstart
 
-        try:
-            fstop = float(self.stop_edit.text())
-        except Exception:
-            # the only case when this field can be empty is when fpoint or fdump are defined
-            if self.stop_edit.text()=="" and (self.fpoint_edit.text() != "" or self.fdump_edit.text() != ""):
-                return True
+        fstop = None
+        if self.stop_edit.text() == "":
+            if discrete_freqs_given:
+                saved_values.pop("fstop", None) # don't leave stale sweep data behind
             else:
                 QMessageBox.warning(self, "Error", "Not a valid value for fstop")
                 self.stop_edit.setText("50")
                 return False
-        saved_values ["fstop"] = float(fstop)
+        else:
+            try:
+                fstop = float(self.stop_edit.text())
+            except Exception:
+                QMessageBox.warning(self, "Error", "Not a valid value for fstop")
+                self.stop_edit.setText("50")
+                return False
+            saved_values ["fstop"] = fstop
 
         if self.step_edit.text() != "":
             try:
@@ -231,10 +245,13 @@ class FrequenciesTab(QWidget):
             saved_values.pop("fdump",None)
 
         # if fstart == fstop == fdump or fstart == fstop == fstep, then remove fstart, fstop
-        if saved_values ["fstart"] == saved_values ["fstop"]:
+        if fstart is not None and fstop is not None and fstart == fstop:
             discrete_list1 = saved_values.get("fpoint", [])
             discrete_list2 = saved_values.get("fdump", [])
-            if saved_values ["fstart"] in discrete_list1 or saved_values ["fstart"] in discrete_list2:
+            if fstart in discrete_list1 or fstart in discrete_list2:
+                saved_values.pop("fstart", None)
+                saved_values.pop("fstop", None)
+                saved_values.pop("fstep", None)
                 self.start_edit.setText("")
                 self.stop_edit.setText("")
                 self.step_edit.setText("")
@@ -243,8 +260,13 @@ class FrequenciesTab(QWidget):
         return True  # Tab change only possible when returning True
 
     def load_values(self):
-        self.start_edit.setText(str(saved_values.get("fstart","0")))
-        self.stop_edit.setText(str(saved_values.get("fstop","50")))
+        # if fstart/fstop were intentionally omitted in favor of fpoint/fdump, keep the
+        # fields blank on reload instead of repopulating the "0"/"50" sweep defaults
+        discrete_freqs_given = ("fpoint" in saved_values) or ("fdump" in saved_values)
+        fstart_default = "" if discrete_freqs_given else "0"
+        fstop_default  = "" if discrete_freqs_given else "50"
+        self.start_edit.setText(str(saved_values.get("fstart",fstart_default)))
+        self.stop_edit.setText(str(saved_values.get("fstop",fstop_default)))
         self.step_edit.setText(str(saved_values.get("fstep","")))
 
         float_list  = saved_values.get("fpoint","")

--- a/src/setupEM/setupEM.py
+++ b/src/setupEM/setupEM.py
@@ -653,7 +653,7 @@ class MeshTab(QWidget):
         self.main_layout.setAlignment(Qt.AlignTop)
 
         label_width = 250
-        edit_width = 150
+        edit_width = 170
 
 
         # ---------- MESH GROUP ----------
@@ -709,7 +709,7 @@ class MeshTab(QWidget):
         self.mesh_order_box = QComboBox()
         self.mesh_order_box.setFixedWidth(edit_width)
         self.mesh_order_box.setStyleSheet(COMBO_STYLE_OPTIONAL)
-        self.mesh_order_box.addItems(["faster, less accurate (N=1)","default (N=2)", "slower, ultra accurate (N=3)"])
+        self.mesh_order_box.addItems(["faster, less accurate (N=1)","recommended (N=2)", "slower, most accurate (N=3)"])
         self.meshorder_layout.addWidget(self.mesh_order_box)
         self.mesh_order_box.setCurrentIndex(0)
         self.meshorder_layout.addStretch()

--- a/src/setupEM/setup_common.py
+++ b/src/setupEM/setup_common.py
@@ -32,7 +32,7 @@ mesh fields, the Python model code generator bodies) is intentionally left
 in setupEM.py / setupThermal.py, not here.
 """
 
-import sys, os, json, pathlib, ast, webbrowser
+import sys, os, json, pathlib, ast, webbrowser, io, contextlib
 import xml.etree.ElementTree as ET
 import numpy as np
 import requests
@@ -497,7 +497,7 @@ class FileInputTab(QWidget):
         self.MainWindow.saved_values["SubstrateFile"] = filename.replace('\\', '/')
         self.update_XML_description(filename)
         self.update_variable_overrides_grid(filename)
-        self.MainWindow.read_XML()  # safe if invalid filename
+        self.MainWindow.read_XML()  # shows an error dialog and keeps prior data on invalid/unparseable XML
         # file is read when leaving the files tab
 
     def update_XML_description(self, filename):
@@ -1834,8 +1834,22 @@ class MainWindowBase(QMainWindow):
     def read_XML(self):
         filename = self.saved_values["SubstrateFile"]
         if pathlib.Path(filename).exists():
-            self.materials_list, self.dielectrics_list, self.metals_list = stackup_reader.read_substrate(
-                filename, variable_overrides=self.saved_values.get("variable_overrides"))
+            captured_stdout = io.StringIO()
+            try:
+                with contextlib.redirect_stdout(captured_stdout):
+                    materials_list, dielectrics_list, metals_list = stackup_reader.read_substrate(
+                        filename, variable_overrides=self.saved_values.get("variable_overrides"))
+            except (Exception, SystemExit) as e:
+                # SystemExit is caught deliberately (not just Exception): the reader
+                # reports hard validation failures (circular/ambiguous Reference,
+                # Offset+Reference conflict, ...) via print(...); exit(1) instead of
+                # raising - see the same pattern in stackupEditor.py's _refresh_preview().
+                # Capture stdout so that printed ERROR text (otherwise invisible in a
+                # GUI with no attached console) can be shown to the user.
+                details = captured_stdout.getvalue().strip() or str(e)
+                QMessageBox.critical(self, "Error", f"Could not load stackup {filename}:\n\n{details}")
+                return  # keep last-known-good materials_list/dielectrics_list/metals_list
+            self.materials_list, self.dielectrics_list, self.metals_list = materials_list, dielectrics_list, metals_list
             self.update_target_layer_choices(self.metals_list)
             self.file_tab.update_XML_description(filename)
             self.file_tab.update_variable_overrides_grid(filename)


### PR DESCRIPTION
## Summary
- Fix Frequencies tab silently dropping (or reusing stale) fstart/fstop when left blank in favor of a fixed frequency list (fpoint/fdump)
- Add a "slower, most accurate (N=3)" mesh basis function option, restricted to Palace mode since Elmer has no third-order solver templates
- Fix crash in Show Stackup preview on invalid stackup XML
- Bump minimum gds2palace dependency to 0.4.0
- Remove outdated polygons-with-holes preprocessing note from README
- Bump version to 0.3.16 (published to PyPI)

## Test plan
- [x] Verified Frequencies tab save/load round-trip no longer writes stale fstart/fstop when fpoint/fdump is used instead
- [x] Verified N=3 mesh option enables/disables correctly when switching between Palace and Elmer mode, and maps to `order=3` in generated settings
- [x] Built and validated the 0.3.16 package with `twine check`, published to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)