### PR TITLE
Mesh refinement overrides, .py-import output-reuse prompt, and consistency fixes (bump to 0.6.0)

### DIFF
--- a/doc/setupEM_userguide.md
+++ b/doc/setupEM_userguide.md
@@ -281,7 +281,7 @@ Use **File > Export to \*.py model** to save the current code to disk without ru
 
 ## File menu
 
-Save and load simulation configurations (JSON, extension `.simcfg` for setupEM / `.tsimcfg` for setupThermal), including a "Default Settings" configuration (stored in your home directory) that's reloaded independently of any project.
+Save and load simulation configurations (JSON, extension `.simcfg` for setupEM / `.tsimcfg` for setupThermal), including a "Default Settings" configuration (stored in your home directory) that's reloaded independently of any project. You can also drag & drop a `.simcfg`/`.tsimcfg` file onto the main window to load it, instead of using **Load Settings ...**.
 
 **Load Settings ...** and **Import from \*.py model ...** each have a **Recent** submenu right below them, listing your last 10 files of that kind for quick reopening; saving a settings file adds it to that list too. Use "Clear Recent Files" in either submenu to reset it.
 

--- a/src/setupEM/__init__.py
+++ b/src/setupEM/__init__.py
@@ -24,4 +24,4 @@ A Python tool for EM setup using gds2palace.
 from .setupEM import main
 
 __all__ = ["main"]
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/setupEM/__init__.py
+++ b/src/setupEM/__init__.py
@@ -24,4 +24,4 @@ A Python tool for EM setup using gds2palace.
 from .setupEM import main
 
 __all__ = ["main"]
-__version__ = "0.5.1"
+__version__ = "0.6.0"

--- a/src/setupEM/palace_results.py
+++ b/src/setupEM/palace_results.py
@@ -82,7 +82,6 @@ def _read_error_indicators(dir_path):
         return {
             'norm': float(fields['Norm']),
             'maximum': float(fields['Maximum']),
-            'mean': float(fields['Mean']),
         }
     except (KeyError, ValueError):
         return None
@@ -281,7 +280,7 @@ def build_results_summary(run_path, model_basename):
         if errors:
             lines.append(
                 f"Error indicator    : Norm={_format_sci(errors['norm'])}  "
-                f"Max={_format_sci(errors['maximum'])}  Mean={_format_sci(errors['mean'])}"
+                f"Max={_format_sci(errors['maximum'])}"
             )
         lines.append("=" * 40)
         return "\n".join(lines)
@@ -289,7 +288,7 @@ def build_results_summary(run_path, model_basename):
     # Adaptive mesh refinement: one row per iteration subfolder, plus the root as "Final"
     rows = _collect_amr_rows(output_dir, iteration_dirs)
 
-    headers = ["Iteration", "DOF", "Mesh elems", "Error Norm", "Error Max", "Error Mean",
+    headers = ["Iteration", "DOF", "Mesh elems", "Error Norm", "Error Max",
                "Max dS", "Time", "Peak RAM"]
     table_rows = []
     for label, summary, errors, delta_s in rows:
@@ -301,7 +300,6 @@ def build_results_summary(run_path, model_basename):
             _format_int(summary.get('mesh_elements')),
             _format_sci(errors.get('norm')),
             _format_sci(errors.get('maximum')),
-            _format_sci(errors.get('mean')),
             _format_delta(delta_s),
             _format_duration(summary.get('duration_s')),
             _format_ram(summary.get('peak_ram_mb')),

--- a/src/setupEM/palace_results.py
+++ b/src/setupEM/palace_results.py
@@ -81,7 +81,6 @@ def _read_error_indicators(dir_path):
     try:
         return {
             'norm': float(fields['Norm']),
-            'minimum': float(fields['Minimum']),
             'maximum': float(fields['Maximum']),
             'mean': float(fields['Mean']),
         }

--- a/src/setupEM/palace_results.py
+++ b/src/setupEM/palace_results.py
@@ -25,6 +25,8 @@ import os
 import json
 import csv
 import re
+import math
+import cmath
 
 _ITERATION_RE = re.compile(r'^iteration(\d+)$')
 
@@ -87,6 +89,115 @@ def _read_error_indicators(dir_path):
         return None
 
 
+def _parse_palace_port_s_csv(path):
+    """Parse a Palace port-S.csv file into (freq_list, S_dB_list, S_arg_list,
+    num_ports), where S_dB_list/S_arg_list are one dict-per-frequency mapping
+    'i j' port-pair strings to their |S| (dB) / phase (deg) string values.
+    """
+    freq = []
+    S_dB = []
+    S_arg = []
+    params = []
+    num_ports = 0
+
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            aline = line.rstrip()
+            aline = aline.replace(",", "")
+            aline = aline.replace("(dB)", "")
+            aline = aline.replace("(deg.)", "")
+
+            if 'Hz)' in aline:
+                # header line: items are like |S[1][1]| arg(S[1][1])
+                items = aline.split()
+                for item in items:
+                    if '|' in item:
+                        Sxx = item.replace('|S', '').replace('|', '')
+                        Sxx = Sxx.replace('][', ' ').replace('[', '').replace(']', '')
+                        params.append(Sxx)
+                        a, b = (int(x) for x in Sxx.split())
+                        num_ports = max(num_ports, a, b)
+                continue
+
+            items = aline.split()
+            if not items:
+                continue
+            dB = {}
+            arg = {}
+            for param in params:
+                dB_index = 2 * params.index(param) + 1
+                arg_index = dB_index + 1
+                dB[param] = items[dB_index]
+                arg[param] = items[arg_index]
+            freq.append(items[0])
+            S_dB.append(dB)
+            S_arg.append(arg)
+
+    return freq, S_dB, S_arg, num_ports
+
+
+def _read_port_s_data(dir_path):
+    """Parse dir_path/port-S.csv (if present), or None if the file is
+    missing, unfinished, or malformed (e.g. a still-running pass).
+    """
+    path = os.path.join(dir_path, 'port-S.csv')
+    if not os.path.isfile(path):
+        return None
+    try:
+        freq, S_dB, S_arg, num_ports = _parse_palace_port_s_csv(path)
+    except (OSError, ValueError, IndexError):
+        return None
+    if not freq:
+        return None
+    return freq, S_dB, S_arg, num_ports
+
+
+def _max_delta_s(prev_data, curr_data):
+    """Max |S_curr - S_prev| across all ports and frequencies common to both
+    passes, mirroring HFSS's per-pass Max Delta S. Returns None if either
+    pass has no port-S data, or the two use different port counts.
+    """
+    if prev_data is None or curr_data is None:
+        return None
+    freq_p, dB_p, arg_p, ports_p = prev_data
+    freq_c, dB_c, arg_c, ports_c = curr_data
+    if ports_p != ports_c:
+        return None
+
+    max_delta = 0.0
+    found_any = False
+    for idx in range(min(len(freq_p), len(freq_c))):
+        for key in set(dB_p[idx]) & set(dB_c[idx]):
+            try:
+                Sp = cmath.rect(10 ** (float(dB_p[idx][key]) / 20.0), math.radians(float(arg_p[idx][key])))
+                Sc = cmath.rect(10 ** (float(dB_c[idx][key]) / 20.0), math.radians(float(arg_c[idx][key])))
+            except ValueError:
+                continue
+            found_any = True
+            max_delta = max(max_delta, abs(Sc - Sp))
+    return max_delta if found_any else None
+
+
+def _collect_amr_rows(output_dir, iteration_dirs):
+    """One row per AMR iteration subfolder, plus the root output_dir as
+    'Final': (label, palace_json_dict_or_None, error_indicators_dict_or_None,
+    max_delta_s_vs_previous_row_or_None).
+    """
+    dirs_in_order = list(iteration_dirs) + [output_dir]
+    labels = [os.path.basename(d) for d in iteration_dirs] + ["Final"]
+
+    rows = []
+    prev_port_s = None
+    for label, d in zip(labels, dirs_in_order):
+        summary = _read_palace_json(d)
+        errors = _read_error_indicators(d)
+        port_s = _read_port_s_data(d)
+        delta_s = _max_delta_s(prev_port_s, port_s)
+        rows.append((label, summary, errors, delta_s))
+        prev_port_s = port_s
+    return rows
+
+
 def _list_iteration_dirs(output_dir):
     if not os.path.isdir(output_dir):
         return []
@@ -128,6 +239,22 @@ def _format_sci(x):
     return 'n/a' if x is None else f"{x:.3e}"
 
 
+def _format_delta(x):
+    return 'n/a' if x is None else f"{x:.4f}"
+
+
+def _save_convergence_summary(run_path, summary_text):
+    """Save the AMR summary table alongside the run's config.json /
+    port_information.json, so it's available on disk without re-running the
+    simulation or digging through the setupEM log.
+    """
+    try:
+        with open(os.path.join(run_path, "mesh_convergence_summary.txt"), "w", encoding="utf-8") as f:
+            f.write(summary_text + "\n")
+    except OSError:
+        pass
+
+
 def build_results_summary(run_path, model_basename):
     """Return a formatted multi-line summary of Palace results found under run_path,
     or an explanatory message if nothing is there yet.
@@ -161,13 +288,12 @@ def build_results_summary(run_path, model_basename):
         return "\n".join(lines)
 
     # Adaptive mesh refinement: one row per iteration subfolder, plus the root as "Final"
-    rows = [(os.path.basename(it_dir), _read_palace_json(it_dir), _read_error_indicators(it_dir))
-            for it_dir in iteration_dirs]
-    rows.append(("Final", _read_palace_json(output_dir), _read_error_indicators(output_dir)))
+    rows = _collect_amr_rows(output_dir, iteration_dirs)
 
-    headers = ["Iteration", "DOF", "Mesh elems", "Error Norm", "Error Max", "Error Mean", "Time", "Peak RAM"]
+    headers = ["Iteration", "DOF", "Mesh elems", "Error Norm", "Error Max", "Error Mean",
+               "Max dS", "Time", "Peak RAM"]
     table_rows = []
-    for label, summary, errors in rows:
+    for label, summary, errors, delta_s in rows:
         summary = summary or {}
         errors = errors or {}
         table_rows.append([
@@ -177,6 +303,7 @@ def build_results_summary(run_path, model_basename):
             _format_sci(errors.get('norm')),
             _format_sci(errors.get('maximum')),
             _format_sci(errors.get('mean')),
+            _format_delta(delta_s),
             _format_duration(summary.get('duration_s')),
             _format_ram(summary.get('peak_ram_mb')),
         ])
@@ -196,4 +323,6 @@ def build_results_summary(run_path, model_basename):
     for row in table_rows:
         lines.append(fmt_row(row))
     lines.append("=" * len(header_line))
-    return "\n".join(lines)
+    summary_text = "\n".join(lines)
+    _save_convergence_summary(run_path, summary_text)
+    return summary_text

--- a/src/setupEM/result_viewer.py
+++ b/src/setupEM/result_viewer.py
@@ -205,6 +205,32 @@ def find_touchstone_files(target_dir):
     return sorted(matches)
 
 
+# AWS Palace adaptive mesh refinement writes one result snapshot per
+# iteration<N>/ subfolder alongside the final, fully-refined result in the
+# parent directory itself (see _ITERATION_RE in palace_results.py, reverse
+# engineered from real Palace output) - same convention, applied per path
+# component so it matches regardless of how deep target_dir's own scan went.
+_AMR_ITERATION_DIR_RE = re.compile(r'^iteration\d+$')
+
+
+def is_amr_iteration_snapshot(path):
+    """True if path sits inside an AMR "iterationN" output folder, i.e. it's
+    a per-iteration snapshot rather than the final result."""
+    parts = os.path.normpath(path).split(os.sep)
+    return any(_AMR_ITERATION_DIR_RE.match(part) for part in parts)
+
+
+def pick_final_result_file(paths):
+    """Given a list of touchstone file paths, prefer the final result (any
+    path with no "iterationN" component) over AMR per-iteration snapshots;
+    break ties (or fall back, if every path is a snapshot) by newest mtime.
+    Returns None for an empty list."""
+    if not paths:
+        return None
+    final_candidates = [p for p in paths if not is_amr_iteration_snapshot(p)] or paths
+    return max(final_candidates, key=os.path.getmtime)
+
+
 # ------------------------------------------------------------------
 # Result Viewer window
 # ------------------------------------------------------------------
@@ -364,13 +390,12 @@ class ResultViewerWindow(QDialog):
                 item.setFlags(Qt.NoItemFlags)
                 self.file_list.addTopLevelItem(item)
             else:
-                # drop checked paths that no longer exist; auto-check the newest
-                # file if nothing is checked (e.g. first open), so the window
-                # isn't blank
+                # drop checked paths that no longer exist; auto-check the final
+                # result (preferring it over any AMR per-iteration snapshot) if
+                # nothing is checked (e.g. first open), so the window isn't blank
                 self._checked_paths &= set(self._master_files)
                 if not self._checked_paths:
-                    newest = max(self._master_files, key=os.path.getmtime)
-                    self._checked_paths = {newest}
+                    self._checked_paths = {pick_final_result_file(self._master_files)}
 
                 # group by each file's immediate parent directory (relative to
                 # target_dir), not a Palace/Elmer-specific convention like

--- a/src/setupEM/setupEM.py
+++ b/src/setupEM/setupEM.py
@@ -644,6 +644,130 @@ class PortsTab(QWidget):
 
 
 
+class RefinedCellsizeOverrideDialog(QDialog):
+    """Popup editor for settings['refined_cellsize_override'], opened from
+    MeshTab's "Advanced..." button. Lets the user set a different mesh
+    refinement cell size for specific metal/sheet layers, instead of the
+    single global "Mesh refinement at metal edges" value. The Layer column
+    is restricted to metals_list.getallplanarmetals() (conductor/sheet
+    layers) - vias and dielectrics never produce boundary curves in
+    gds2palace's meshing code, so a name outside that list would silently
+    have no effect if it were allowed to be typed in.
+    """
+
+    def __init__(self, parent, layer_choices, current_overrides):
+        super().__init__(parent)
+        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.setWindowTitle("Mesh Refinement Overrides")
+        self.resize(420, 400)
+        self.setModal(True)
+
+        self._layer_choices = layer_choices
+        self._result = []
+
+        layout = QVBoxLayout()
+
+        info = QLabel("Override the mesh refinement cell size for specific layers\n"
+                      "(all other layers keep using the default set above).")
+        layout.addWidget(info)
+
+        self.table = QTableWidget()
+        self.table.setColumnCount(3)
+        self.table.setHorizontalHeaderLabels(["Layer", "Cell size (µm)", ""])
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+        layout.addWidget(self.table)
+
+        for name, value in current_overrides:
+            self._add_row(name, value)
+
+        add_row_layout = QHBoxLayout()
+        add_btn = QPushButton("+ Add Row")
+        add_btn.clicked.connect(lambda: self._add_row())
+        add_row_layout.addWidget(add_btn)
+        add_row_layout.addStretch()
+        layout.addLayout(add_row_layout)
+
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+        ok_btn = QPushButton("OK")
+        ok_btn.clicked.connect(self._on_ok)
+        button_layout.addWidget(ok_btn)
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self.reject)
+        button_layout.addWidget(cancel_btn)
+        layout.addLayout(button_layout)
+
+        self.setLayout(layout)
+
+    def _add_row(self, name="", value=""):
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+
+        combo = QComboBox()
+        combo.setStyleSheet(COMBO_STYLE_OPTIONAL)
+        combo.addItem("")
+        combo.addItems(self._layer_choices)
+        if name and name not in self._layer_choices:
+            # tolerate a saved override for a layer no longer in the current
+            # stackup, same tolerant style as the Cellname combo box
+            combo.addItem(name)
+        if name:
+            combo.setCurrentText(name)
+        self.table.setCellWidget(row, 0, combo)
+
+        value_text = "" if value == "" else str(value)
+        self.table.setItem(row, 1, QTableWidgetItem(value_text))
+
+        remove_btn = QPushButton("✕")
+        remove_btn.setFixedWidth(28)
+        remove_btn.clicked.connect(lambda: self._remove_row_containing(remove_btn))
+        self.table.setCellWidget(row, 2, remove_btn)
+
+    def _remove_row_containing(self, button):
+        # look up the row by identity rather than a captured index, since
+        # row indices shift whenever an earlier row is removed
+        for row in range(self.table.rowCount()):
+            if self.table.cellWidget(row, 2) is button:
+                self.table.removeRow(row)
+                return
+
+    def _on_ok(self):
+        overrides = []
+        seen_layers = set()
+        for row in range(self.table.rowCount()):
+            combo = self.table.cellWidget(row, 0)
+            layer = combo.currentText().strip() if combo else ""
+            if not layer:
+                continue  # blank row - not yet configured, skip silently
+
+            value_item = self.table.item(row, 1)
+            value_text = value_item.text().strip() if value_item else ""
+            try:
+                value = float(value_text)
+                if value <= 0:
+                    raise ValueError
+            except ValueError:
+                QMessageBox.warning(self, "Error", f"Not a valid cell size for layer '{layer}'")
+                return
+
+            if layer in seen_layers:
+                QMessageBox.warning(self, "Error", f"Layer '{layer}' is selected more than once")
+                return
+            seen_layers.add(layer)
+            overrides.append([layer, value])
+
+        self._result = overrides
+        self.accept()
+
+    def get_overrides(self):
+        return self._result
+
+
 class MeshTab(QWidget):
     def __init__(self, MainWindow):
         super().__init__()
@@ -662,42 +786,44 @@ class MeshTab(QWidget):
         self.mesh_layout = QVBoxLayout()
 
         self.refinement_layout = QHBoxLayout()
-        self.label2 = QLabel("Mesh refinement at metal edges")
+        self.label2 = QLabel("Mesh refinement at metal edges (µm)")
         self.label2.setFixedWidth(label_width)
         self.refinement_layout.addWidget(self.label2)
         self.refinement_edit = QLineEdit("5")
         self.refinement_edit.setFixedWidth(edit_width)
         self.refinement_edit.setStyleSheet(EDIT_STYLE_REQUIRED)
         self.refinement_layout.addWidget(self.refinement_edit)
-        self.label3 = QLabel(" µm ")
-        self.refinement_layout.addWidget(self.label3)
+        self.refined_override_btn = QPushButton("Advanced...")
+        self.refined_override_btn.clicked.connect(self.open_refined_cellsize_override_dialog)
+        self.refinement_layout.addWidget(self.refined_override_btn)
         self.refinement_layout.addStretch()
         self.mesh_layout.addLayout(self.refinement_layout)
 
+        # in-memory copy of settings['refined_cellsize_override'] (list of
+        # [layername, value] pairs), edited via the "Advanced..." dialog;
+        # harvested into saved_values by save_values() like every other field
+        self._refined_cellsize_override = []
+
         self.cells_lambda_layout = QHBoxLayout()
-        self.label4 = QLabel("Mesh cells per wavelength")
+        self.label4 = QLabel("Mesh cells per wavelength (min 10)")
         self.label4.setFixedWidth(label_width)
         self.cells_lambda_layout.addWidget(self.label4)
         self.cells_lambda_edit = QLineEdit("10")
         self.cells_lambda_edit.setFixedWidth(edit_width)
         self.cells_lambda_edit.setStyleSheet(EDIT_STYLE_OPTIONAL)
         self.cells_lambda_layout.addWidget(self.cells_lambda_edit)
-        self.label5 = QLabel(" (min 10)")
-        self.cells_lambda_layout.addWidget(self.label5)
         self.cells_lambda_layout.addStretch()
         self.mesh_layout.addLayout(self.cells_lambda_layout)
 
 
         self.cells_maxsize_layout = QHBoxLayout()
-        self.label6 = QLabel("Mesh cell maximum size absolute")
+        self.label6 = QLabel("Mesh cell maximum size absolute (µm)")
         self.label6.setFixedWidth(label_width)
         self.cells_maxsize_layout.addWidget(self.label6)
         self.cells_maxsize_edit = QLineEdit("100")
         self.cells_maxsize_edit.setFixedWidth(edit_width)
         self.cells_maxsize_edit.setStyleSheet(EDIT_STYLE_OPTIONAL)
         self.cells_maxsize_layout.addWidget(self.cells_maxsize_edit)
-        self.label5 = QLabel(" µm ")
-        self.cells_maxsize_layout.addWidget(self.label5)
         self.cells_maxsize_layout.addStretch()
         self.mesh_layout.addLayout(self.cells_maxsize_layout)
 
@@ -916,6 +1042,22 @@ class MeshTab(QWidget):
         self.setLayout(self.main_layout)
 
 
+    def _update_refined_override_button_label(self):
+        n = len(self._refined_cellsize_override)
+        self.refined_override_btn.setText(f"Advanced... ({n})" if n > 0 else "Advanced...")
+
+    def open_refined_cellsize_override_dialog(self):
+        metals_list = self.MainWindow.metals_list
+        if metals_list is None:
+            QMessageBox.warning(self, "Error", "Load a GDSII file and XML stackup first")
+            return
+
+        layer_choices = [metal.name for metal in metals_list.getallplanarmetals()]
+        dialog = RefinedCellsizeOverrideDialog(self, layer_choices, self._refined_cellsize_override)
+        if dialog.exec() == QDialog.Accepted:
+            self._refined_cellsize_override = dialog.get_overrides()
+            self._update_refined_override_button_label()
+
     def on_meshorder_changed(self, value):
     # callback when mesh order changed, so that we can show/hide edit fields
         try:
@@ -952,6 +1094,7 @@ class MeshTab(QWidget):
             self.refinement_edit.setText("5")
             return False
         saved_values ["refined_cellsize"] = float(value)
+        saved_values ["refined_cellsize_override"] = self._refined_cellsize_override
 
         saved_values ["order"] = self.mesh_order_box.currentIndex()+1
 
@@ -1053,6 +1196,8 @@ class MeshTab(QWidget):
 
     def load_values(self):
         self.refinement_edit.setText(str(saved_values.get("refined_cellsize","5")))
+        self._refined_cellsize_override = list(saved_values.get("refined_cellsize_override", []))
+        self._update_refined_override_button_label()
         self.cells_lambda_edit.setText(str(saved_values.get("cells_per_wavelength","10")))
         self.cells_maxsize_edit.setText(str(saved_values.get("meshsize_max","100")))
         self.AMR_iterations_edit.setText(str(saved_values.get("adaptive_mesh_iterations","0")))
@@ -1080,17 +1225,23 @@ class MeshTab(QWidget):
             self.airaround_edit.setText(saved_values.get("margin","200"))
             self.airaround_box.setCurrentIndex(0)
         else:
-            if "," in str(air):
-                # we have a list of 6 values
-                air_as_list = air.split(',')
-                if len(air_as_list) == 6:
-                    self.airaround_box.setCurrentIndex(1)
-                    self.airxmin_edit.setText(air_as_list[0])
-                    self.airxmax_edit.setText(air_as_list[1])
-                    self.airymin_edit.setText(air_as_list[2])
-                    self.airymax_edit.setText(air_as_list[3])
-                    self.airzmin_edit.setText(air_as_list[4])
-                    self.airzmax_edit.setText(air_as_list[5])
+            # native JSON round-trip stores this as a real list of floats;
+            # .py import stores it as a comma-separated string instead
+            if isinstance(air, list):
+                air_as_list = [str(v) for v in air]
+            elif "," in str(air):
+                air_as_list = [v.strip() for v in str(air).split(',')]
+            else:
+                air_as_list = None
+
+            if air_as_list and len(air_as_list) == 6:
+                self.airaround_box.setCurrentIndex(1)
+                self.airxmin_edit.setText(air_as_list[0])
+                self.airxmax_edit.setText(air_as_list[1])
+                self.airymin_edit.setText(air_as_list[2])
+                self.airymax_edit.setText(air_as_list[3])
+                self.airzmin_edit.setText(air_as_list[4])
+                self.airzmax_edit.setText(air_as_list[5])
             else:
                 # we have air_around defined as a single value
                 self.airaround_box.setCurrentIndex(0)
@@ -1171,9 +1322,9 @@ class CreateModelTab(CreateModelTabBase):
         # local import: only needed once snp2le is actually launched, same lazy-import
         # style used by open_result_viewer() for its own heavy imports.
         if __package__ in (None, ""):
-            from result_viewer import find_touchstone_files
+            from result_viewer import find_touchstone_files, is_amr_iteration_snapshot
         else:
-            from .result_viewer import find_touchstone_files
+            from .result_viewer import find_touchstone_files, is_amr_iteration_snapshot
 
         if self.MainWindow.PalaceMode:
             run_path = saved_values['sim_path'] + "/palace_model/" + saved_values['model_basename'] + "_data"
@@ -1189,23 +1340,28 @@ class CreateModelTab(CreateModelTabBase):
             QMessageBox.warning(self, "Model Fit",
                                  f"No raw S-parameter result file found in {run_path}.\nRun a simulation first.")
             return
-        if len(raw_files) > 1:
-            self.log_area.appendPlainText("⚠️ Multiple raw S-parameter result files found, using the first one:")
-            for path in raw_files:
-                self.log_area.appendPlainText("  " + path)
-        raw_file = raw_files[0]
 
-        # snp2le's GUI mode takes no filename argument (only its "-b" batch mode does) -
-        # the file has to be loaded by hand via the GUI's own file picker, so point the
-        # user at it explicitly and start snp2le in that file's directory, so its file
-        # picker opens there instead of wherever setupEM happened to be launched from.
+        # adaptive mesh refinement leaves one snapshot touchstone file per
+        # iteration<N>/ subfolder alongside the final, fully-refined result
+        # directly in run_path - prefer that final result over the snapshots.
+        final_candidates = [p for p in raw_files if not is_amr_iteration_snapshot(p)] or raw_files
+        if len(final_candidates) > 1:
+            self.log_area.appendPlainText("⚠️ Multiple raw S-parameter result files found, using the newest one:")
+            for path in final_candidates:
+                self.log_area.appendPlainText("  " + path)
+        raw_file = max(final_candidates, key=os.path.getmtime)
+
+        # naming a .sNp file on the command line opens snp2le's GUI on it directly
+        # (see https://github.com/iic-jku/snp2le/blob/main/doc/architecture.md);
+        # still start it in that file's directory, so any relative paths it uses
+        # (e.g. for exporting a fit) resolve there instead of wherever setupEM
+        # happened to be launched from.
         raw_dir = os.path.dirname(raw_file)
-        self.log_area.appendPlainText("Starting snp2le ...")
+        self.log_area.appendPlainText(f"Starting snp2le on {raw_file} ...")
         self.log_area.appendPlainText(SNP2LE_URL)
-        self.log_area.appendPlainText(f"In the snp2le window, load: {raw_file}")
         self._process_purpose = "model_fit"
         self.process.setWorkingDirectory(raw_dir)
-        self.process.start(sys.executable, ["-m", "snp2le"])
+        self.process.start(sys.executable, ["-m", "snp2le", raw_file])
 
     def _append_results_summary(self):
         # Palace-only: parse palace.json / error-indicators.csv and append a results summary
@@ -1516,7 +1672,7 @@ class ModelEditorTab(QWidget):
 
         if forExport:
             # these commands are only used within this GUI application to control gmsh
-            ignore_list.append(['preview_only','no_preview'])
+            ignore_list.extend(['preview_only','no_preview'])
 
         for key in saved_values.keys():
             if not key in special_keylist:
@@ -1802,20 +1958,30 @@ class MainWindow(MainWindowBase):
     def apply_native_config_data(self, data):
         # update ports, they are separate from the other internal data
         self.ports_tab.update_port_from_import(data.get("ports"))
+        # restore simulator mode (not part of saved_values, see native_config_extra_struct)
+        if data.get("elmer_mode", False):
+            self.setElmerMode()
+        else:
+            self.setPalaceMode()
 
     def apply_python_import_data(self, file_path):
         # read port assignments in workflow syntax for gds2palace Python code
         ports = parse_python_ports_definitions(file_path)
         self.ports_tab.update_port_from_import(ports)
 
-        # set simulator
-        if self.saved_values.get("elmer", False):
+        # Elmer/Palace mode is expressed only by which simulation_setup.create_*()
+        # call the script makes, never as a literal settings['elmer'] assignment
+        # (parse_assignments() skips lines whose value contains "settings"), so
+        # detect it directly from the source text instead.
+        with open(file_path) as f:
+            text = f.read()
+        if "create_elmer(" in text:
             self.setElmerMode()
         else:
             self.setPalaceMode()
 
     def native_config_extra_struct(self):
-        return {"ports": simulation_ports_to_struct(simulation_ports)}
+        return {"ports": simulation_ports_to_struct(simulation_ports), "elmer_mode": self.ElmerMode}
 
     def update_target_layer_choices(self, metals_list):
         self.ports_tab.update_layers(metals_list)

--- a/src/setupEM/setupThermal.py
+++ b/src/setupEM/setupThermal.py
@@ -486,7 +486,7 @@ class MeshTab(QWidget):
         self.label6 = QLabel("Mesh cell maximum size")
         self.label6.setFixedWidth(label_width)
         self.cells_maxsize_layout.addWidget(self.label6)
-        self.cells_maxsize_edit = QLineEdit("10")
+        self.cells_maxsize_edit = QLineEdit("100")
         self.cells_maxsize_edit.setFixedWidth(edit_width)
         self.cells_maxsize_edit.setStyleSheet(EDIT_STYLE_OPTIONAL)
         self.cells_maxsize_layout.addWidget(self.cells_maxsize_edit)
@@ -507,7 +507,7 @@ class MeshTab(QWidget):
         self.label7 = QLabel("Dielectric stackup: oversize by")
         self.label7.setFixedWidth(label_width)
         self.margins_layout.addWidget(self.label7)
-        self.margins_edit = QLineEdit("200")
+        self.margins_edit = QLineEdit("100")
         self.margins_edit.setFixedWidth(edit_width)
         self.margins_edit.setStyleSheet(EDIT_STYLE_REQUIRED)
         self.margins_layout.addWidget(self.margins_edit)
@@ -545,7 +545,7 @@ class MeshTab(QWidget):
             value = float(self.margins_edit.text())
         except Exception:
             QMessageBox.warning(self, "Error", "Not a valid value for dielectric oversize margin")
-            self.margins_edit.setText("200")
+            self.margins_edit.setText("100")
             return False
         saved_values ["margin"] = float(value)
 
@@ -737,7 +737,7 @@ class ModelEditorTab(QWidget):
 
         if forExport:
             # these commands are only used within this GUI application to control gmsh
-            ignore_list.append(['preview_only','no_preview'])
+            ignore_list.extend(['preview_only','no_preview'])
 
         for key in saved_values.keys():
             if not key in special_keylist:

--- a/src/setupEM/setup_common.py
+++ b/src/setupEM/setup_common.py
@@ -324,7 +324,7 @@ class FileInputTab(QWidget):
         self.viamerge_layout = QHBoxLayout()
         self.viamerge_label1 = QLabel("Merge via arrays with spacing ")
         self.viamerge_label1.setFixedWidth(left_label_width)
-        self.viamerge_edit = QLineEdit("0")
+        self.viamerge_edit = QLineEdit("0.5")
         self.viamerge_edit.setStyleSheet(EDIT_STYLE_OPTIONAL)
         self.viamerge_edit.setFixedWidth(70)
         self.viamerge_label2 = QLabel(" micron or more, value 0 disables via array merging")
@@ -643,7 +643,7 @@ class FileInputTab(QWidget):
             merge_polygon_size = float(self.viamerge_edit.text())
         except Exception:
             QMessageBox.warning(self, "Error", f"Not a valid value for via array merging")
-            self.viamerge_edit.setText("0")
+            self.viamerge_edit.setText("0.5")
             return False
         saved_values["merge_polygon_size"] = float(merge_polygon_size)
 
@@ -1669,6 +1669,8 @@ class MainWindowBase(QMainWindow):
                     "XML_filename": "SubstrateFile",
                     "GdsFile": "GdsFile",
                     "purpose": "purpose",
+                    "cellname": "cellname",
+                    "variable_overrides": "variable_overrides",
                     "SubstrateFile": "SubstrateFile",
                     "merge_polygon_size": "merge_polygon_size",
                     "preprocess_gds": "preprocess_gds",
@@ -1681,12 +1683,12 @@ class MainWindowBase(QMainWindow):
                     "fpoint": "fpoint",
                     "fdump": "fdump",
                     "refined_cellsize": "refined_cellsize",
+                    "refined_cellsize_override": "refined_cellsize_override",
                     "cells_per_wavelength": "cells_per_wavelength",
                     "meshsize_max": "meshsize_max",
                     "adaptive_mesh_iterations": "adaptive_mesh_iterations",
                     "order": "order",
                     "iterative": "iterative",
-                    "elmer": "elmer",
                     "ELMER_MPI_THREADS": "ELMER_MPI_THREADS"
                 }
 
@@ -1706,7 +1708,7 @@ class MainWindowBase(QMainWindow):
                             if import_key not in import_value:  # skip the section where key might appear in different context
                                 # get the internal name for this variable
                                 varname = import_mapping.get(import_key, '')
-                                if varname == "fpoint" or varname == "fdump":
+                                if varname in ("fpoint", "fdump", "variable_overrides", "refined_cellsize_override"):
                                     saved_values[varname] = ast.literal_eval(import_value)
                                 elif varname in ["gds_filename", "XML_filename", "GdsFile", "SubstrateFile"]:
                                     # check if we have full path for files in imported Python script,
@@ -1726,6 +1728,19 @@ class MainWindowBase(QMainWindow):
                                         saved_values[varname] = int(raw)
                                     else:
                                         saved_values[varname] = raw
+
+                # ask whether future "Create Model" output should overwrite this same
+                # file, or start a fresh model (today's GDS-derived default)
+                reuse = QMessageBox.question(
+                    self, "Import Model",
+                    f"Use '{os.path.basename(file_path)}' as the output file for this model too?\n\n"
+                    "Yes: Create Model / Start Simulation will overwrite this file.\n"
+                    "No: pick a model name and target directory on the Create Model(s) tab.",
+                    QMessageBox.Yes | QMessageBox.No, QMessageBox.No
+                ) == QMessageBox.Yes
+                if reuse:
+                    saved_values['sim_path'] = os.path.dirname(file_path).replace('\\', '/')
+                    saved_values['model_basename'] = pathlib.Path(file_path).stem
 
                 # read port/thermal assignments in workflow syntax for gds2palace Python code, and
                 # apply any app-specific post-import state (e.g. setupEM's simulator mode)

--- a/src/setupEM/setup_common.py
+++ b/src/setupEM/setup_common.py
@@ -1411,6 +1411,42 @@ class MainWindowBase(QMainWindow):
 
     TAB_HEADER_COLORS = ["#FFCDD2", "#C8E6C9", "#BBDEFB", "#FFF9C4", "#D1C4E9"]
 
+    def __init__(self):
+        super().__init__()
+        # let the whole window accept a dropped *.simcfg / *.tsimcfg file,
+        # not just the individual file-path fields (see FileDropLineEdit)
+        self.setAcceptDrops(True)
+
+    # ---------- Drag & drop native config file onto the window ----------
+    def _config_file_from_drop(self, event):
+        if not event.mimeData().hasUrls():
+            return None
+        for url in event.mimeData().urls():
+            path = url.toLocalFile()
+            if path and pathlib.Path(path).suffix.upper() == "." + self.CONFIG_SUFFIX.upper():
+                return path
+        return None
+
+    def dragEnterEvent(self, event):
+        if self._config_file_from_drop(event):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dragMoveEvent(self, event):
+        if self._config_file_from_drop(event):
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event):
+        file_path = self._config_file_from_drop(event)
+        if file_path:
+            event.acceptProposedAction()
+            self.load_configuration_from_file(file_path)
+        else:
+            event.ignore()
+
     # ---------- Menu Bar ----------
     def create_menu_bar(self):
         menu_bar = self.menuBar()


### PR DESCRIPTION
## Summary
- Advanced per-layer mesh refinement override editor (`refined_cellsize_override`), opened via a new "Advanced..." button next to the mesh refinement field
- Prompt on `.py` model import asking whether to reuse the imported file's own path/name for future "Create Model" output
- `snp2le` (Model Fit) now launches with the result file passed as a command-line argument instead of printing manual load instructions
- Result Viewer / Model Fit now prefer the final (non-AMR-iteration) result file over per-iteration snapshots
- Drag & drop support for `*.simcfg`/`*.tsimcfg` files, plus AMR convergence-metric and error-indicator reporting improvements
- Fixes: `cellname`/`variable_overrides` silently dropped on `.py` re-import, Elmer/Palace simulator mode not persisted across JSON save/load or `.py` import, a crash loading JSON settings with per-side air margins, and other dormant-bug/dead-default-literal cleanups
- Bump version to 0.6.0

## Test plan
- [x] Syntax-checked all changed files
- [x] Headless Qt tests of the new Advanced override dialog (add/remove rows, validation, duplicate-layer/invalid-value blocking, stale-layer tolerance)
- [x] Verified the `.py` export/import round-trip for `cellname`/`variable_overrides`/`refined_cellsize_override`
- [ ] Manual GUI click-through in a running setupEM/setupThermal session

🤖 Generated with [Claude Code](https://claude.com/claude-code)