### PR TITLE
Elmer EM fixes, ParaView viewers, and workflow improvements

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,4 +1,12 @@
 
+# What's New - September 5, 2026
+
+Added a **View fields in Paraview...** button (Create Model tab), shown once `fdump` is set, to open Palace or Elmer EM field-dump results directly. "View Results..." is renamed to **View S-Parameters...** for clarity.
+
+Fixed Elmer EM simulations failing to start on Windows: the run script never actually launched (silently, with no log output), and MPI-enabled runs now check that Microsoft MPI is installed first, with a clear message and download link if it's missing instead of a cryptic failure.
+
+Fixed importing an existing model file and choosing to reuse its filename: it could silently rename the output to a different file than the one imported. Fixed `fdump`/`fpoint` showing raw Hz values instead of GHz after importing a model file. `fdump` is now usable in Elmer mode too (previously hidden).
+
 # What's New - September 1, 2026
 
 Added a built-in **Result Viewer** (Create Model tab > View Results...) for browsing Touchstone S-parameter results without leaving setupEM: a file tree grouped by run folder (check a whole folder or individual files), dB/phase or Smith/zoomed-Smith charts with a shared legend, and `_dc`/`_deembedded` filter checkboxes. Also runnable standalone via the `resultViewer` script.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ dependencies = [
     "scikit-rf",
     "matplotlib",
     "numpy",
-    "gdspy"
+    "gdspy",
+    "meshio"
 ]
 requires-python = ">=3.9"
 

--- a/src/setupEM/palace_results.py
+++ b/src/setupEM/palace_results.py
@@ -27,6 +27,7 @@ import csv
 import re
 import math
 import cmath
+import glob
 
 _ITERATION_RE = re.compile(r'^iteration(\d+)$')
 
@@ -45,6 +46,23 @@ def find_output_dir(run_path, model_basename):
     if not output_rel:
         output_rel = 'output/' + model_basename
     return os.path.normpath(os.path.join(run_path, output_rel))
+
+
+def find_paraview_files(run_path, model_basename):
+    """All ParaView collection files under this run's Palace output directory, found
+    recursively. Palace's own field-dump feature (triggered by fdump/SaveStep) writes
+    its category/excitation folder structure without gds2palace's control - confirmed
+    (on two Palace versions) to only keep the last-solved excitation's Cycle files, so
+    no fixed filename or count can be assumed here. Falls back to loose .vtu if no .pvd
+    exists yet. Empty list if the output directory doesn't exist / has nothing yet.
+    """
+    output_dir = find_output_dir(run_path, model_basename)
+    if not os.path.isdir(output_dir):
+        return []
+    pvd_files = sorted(glob.glob(os.path.join(output_dir, '**', '*.pvd'), recursive=True))
+    if pvd_files:
+        return pvd_files
+    return sorted(glob.glob(os.path.join(output_dir, '**', '*.vtu'), recursive=True))
 
 
 def _read_palace_json(dir_path):

--- a/src/setupEM/setupEM.py
+++ b/src/setupEM/setupEM.py
@@ -2033,13 +2033,20 @@ class MainWindow(MainWindowBase):
         ports = parse_python_ports_definitions(file_path)
         self.ports_tab.update_port_from_import(ports)
 
-        # Elmer/Palace mode is expressed only by which simulation_setup.create_*()
-        # call the script makes, never as a literal settings['elmer'] assignment
-        # (parse_assignments() skips lines whose value contains "settings"), so
-        # detect it directly from the source text instead.
+        # Elmer/Palace mode isn't captured by the general settings-dict import
+        # (parse_assignments() skips lines whose value contains "settings", and
+        # 'elmer' isn't in import_mapping anyway), so detect it directly from the
+        # source text instead. Two valid ways a script selects Elmer mode:
+        #  - calling simulation_setup.create_elmer(...) (what create_model_text()
+        #    itself generates, with a space before "(" - a plain "create_elmer("
+        #    substring check never matches that)
+        #  - setting settings['elmer'] = True directly and calling create_model()
+        #    itself (create_elmer() is only a thin wrapper that sets this same flag)
         with open(file_path) as f:
             text = f.read()
-        if "create_elmer(" in text:
+        elmer_call = re.search(r'create_elmer\s*\(', text)
+        elmer_flag = re.search(r'settings\s*\[\s*[\'"]elmer[\'"]\s*\]\s*=\s*True\b', text, re.IGNORECASE)
+        if elmer_call or elmer_flag:
             self.setElmerMode()
         else:
             self.setPalaceMode()

--- a/src/setupEM/setupEM.py
+++ b/src/setupEM/setupEM.py
@@ -17,7 +17,7 @@
 ########################################################################
 
 
-import sys, json, os, pathlib, ast, webbrowser, argparse, shutil, re
+import sys, json, os, pathlib, ast, webbrowser, argparse, shutil, re, glob
 import numpy as np
 import importlib.metadata
 import importlib.util
@@ -55,7 +55,7 @@ if __package__ in (None, ""):
         VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
         epsilon_to_color, default_stackup_dielectric_label, default_stackup_metal_label,
     )
-    from palace_results import build_results_summary, find_output_dir
+    from palace_results import build_results_summary, find_output_dir, find_paraview_files
 else:
     from .setup_common import (
         EDIT_STYLE_OPTIONAL, EDIT_STYLE_REQUIRED, COMBO_STYLE_REQUIRED, COMBO_STYLE_OPTIONAL,
@@ -63,7 +63,7 @@ else:
         VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
         epsilon_to_color, default_stackup_dielectric_label, default_stackup_metal_label,
     )
-    from .palace_results import build_results_summary, find_output_dir
+    from .palace_results import build_results_summary, find_output_dir, find_paraview_files
 
 
 '''
@@ -244,6 +244,8 @@ class FrequenciesTab(QWidget):
             saved_values ["fdump"] = ast.literal_eval('['+text+']')
         else:
             saved_values.pop("fdump",None)
+        # "View fields in Paraview" is only relevant once fdump is set
+        self.MainWindow.create_model_tab._update_paraview_button_visibility()
 
         # if fstart == fstop == fdump or fstart == fstop == fstep, then remove fstart, fstop
         if fstart is not None and fstop is not None and fstart == fstop:
@@ -1285,12 +1287,25 @@ class CreateModelTab(CreateModelTabBase):
         # up exactly with Preview/Create Mesh/Start Simulation above, in the same
         # Actions group.
         row = self.buttons_grid.rowCount()
-        self.view_results_btn = QPushButton("📈 View Results...")
+        self.view_results_btn = QPushButton("📈 View S-Parameters...")
         self.view_results_btn.clicked.connect(self.MainWindow.open_result_viewer)
         self.buttons_grid.addWidget(self.view_results_btn, row, 0)
         self.model_fit_btn = QPushButton("🧩 Model Fit...")
         self.model_fit_btn.clicked.connect(self.open_model_fit)
         self.buttons_grid.addWidget(self.model_fit_btn, row, 1)
+
+        # "View fields in Paraview" opens field-dump data (Palace fdump / Elmer EM
+        # fields*.vtu), a separate row since it's independent of the S-parameter
+        # viewer/model fit above. Only meaningful when fdump is set (otherwise there's
+        # never any field data to open), so it's hidden rather than shown greyed-out -
+        # kept in sync with saved_values['fdump'] via _update_paraview_button_visibility(),
+        # called from here, from load_values() (project/model import), and from
+        # FrequenciesTab.save_values() (live edits to the fdump field).
+        row = self.buttons_grid.rowCount()
+        self.paraview_btn = QPushButton("🖼️ View fields in Paraview...")
+        self.paraview_btn.clicked.connect(self.launch_paraview)
+        self.buttons_grid.addWidget(self.paraview_btn, row, 0)
+        self._update_paraview_button_visibility()
 
     def open_model_fit(self):
         SNP2LE_URL = "https://github.com/iic-jku/snp2le"
@@ -1369,6 +1384,43 @@ class CreateModelTab(CreateModelTabBase):
         run_path = saved_values['sim_path'] + "/palace_model/" + saved_values['model_basename'] + "_data"
         summary = build_results_summary(run_path, saved_values['model_basename'])
         self.log_area.appendPlainText("\n" + summary + "\n")
+
+    def _update_paraview_button_visibility(self):
+        self.paraview_btn.setVisible(bool(saved_values.get('fdump')))
+
+    def load_values(self):
+        super().load_values()
+        self._update_paraview_button_visibility()
+
+    def launch_paraview(self):
+        if self.MainWindow.PalaceMode:
+            run_path = saved_values['sim_path'] + "/palace_model/" + saved_values['model_basename'] + "_data"
+            file_paths = find_paraview_files(run_path, saved_values['model_basename'])
+            not_found = (
+                f"⚠️ No Palace field-dump output found under "
+                f"{find_output_dir(run_path, saved_values['model_basename'])}\n"
+                "(set fdump to specific frequencies before running the simulation)\n"
+            )
+        else:
+            run_path = saved_values['sim_path'] + "/elmer_model/" + saved_values['model_basename'] + "_data"
+            # Output File Name = File "fields" has no path prefix, so Elmer resolves it
+            # relative to the Mesh DB directory ("mesh" under run_path) rather than
+            # run_path itself - confirmed against a real run (same resolution mechanism
+            # found for thermal_results.vtu). Check run_path too, defensively.
+            search_dirs = [os.path.join(run_path, "mesh"), run_path]
+            file_paths = []
+            for pattern in ("fields*.pvd", "fields*.vtu"):
+                for d in search_dirs:
+                    file_paths = sorted(glob.glob(os.path.join(d, pattern)))
+                    if file_paths:
+                        break
+                if file_paths:
+                    break
+            not_found = (
+                f"⚠️ No Elmer field-dump output found under {run_path}\n"
+                "(set fdump to specific frequencies before running the simulation)\n"
+            )
+        self._open_in_paraview(file_paths, not_found)
 
     def on_finished(self, exit_code, exit_status):
         super().on_finished(exit_code, exit_status)
@@ -1546,17 +1598,27 @@ class CreateModelTab(CreateModelTabBase):
 
                 self.log_area.appendPlainText('Setting work directory ' + run_path)
 
-                # rename file to batch file, but only if that has not already
-                # been done by a previous run (otherwise os.rename() fails on
-                # the second run because run_elmer no longer exists)
-                run_file_orig = os.path.join(run_path, 'run_elmer')
-                run_file = run_file_orig.replace('run_elmer','run_elmer.bat')
-                if os.path.exists(run_file_orig):
-                    os.rename(run_file_orig, run_file)
-
+                # create_elmer_run_script() (util_utilities.py) writes run_elmer.bat
+                # directly on Windows (proper .bat content - no "#!/bin/bash" shebang,
+                # and MS-MPI's "mpiexec -n N" instead of the Linux-only "mpirun -np N"),
+                # so no rename step is needed here any more.
+                if saved_values.get('ELMER_MPI_THREADS', 1) > 1 and shutil.which("mpiexec") is None:
+                    self.log_area.appendPlainText(
+                        "⚠️ This model requests MPI multithreading, but 'mpiexec' was not "
+                        "found on PATH. On Windows, Elmer uses Microsoft MPI - download and "
+                        "install it from "
+                        "https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi "
+                        "and restart setupEM, or switch to 1 thread (no multithreading) on the "
+                        "Mesh and Boundaries tab.\n"
+                    )
+                    return
                 self.process.setWorkingDirectory(run_path)
-                # start simulation
-                self.process.start("run_elmer.bat")
+                # start simulation - full path, not just "run_elmer.bat": Windows'
+                # CreateProcess resolves a bare relative program name against the
+                # CALLING process's own cwd/PATH, not the child's setWorkingDirectory(),
+                # so a bare filename here silently fails with FailedToStart even though
+                # setWorkingDirectory() is set correctly.
+                self.process.start(os.path.join(run_path, "run_elmer.bat"))
             else:
                 # Linux
                 self.log_area.appendPlainText('Setting work directory ' + run_path)
@@ -1895,7 +1957,9 @@ class MainWindow(MainWindowBase):
         self.PalaceMode = False
         self.ElmerMode  = True
         self.setWindowTitle(APP_NAME + ' Elmer')
-        self.frequencies_tab.dump_group.setVisible(False)
+        # fdump now also enables Elmer EM field dumps (Exec Solver = Always), not just
+        # Palace's SaveStep - so this group must stay visible/usable in Elmer mode too.
+        self.frequencies_tab.dump_group.setVisible(True)
         self.mesh_tab.AMR_group.setVisible(False)
         self.mesh_tab.Elmer_group.setVisible(True)
 

--- a/src/setupEM/setupEM.py
+++ b/src/setupEM/setupEM.py
@@ -1483,9 +1483,13 @@ class CreateModelTab(CreateModelTabBase):
 
         Palace writes all of its results into one dedicated subdirectory (named in
         config.json's Problem.Output, resolved via find_output_dir()), so that whole
-        subtree is the deletion target. Elmer has no such subdirectory - its solver
-        writes scalar_results.*/fields*.vtu*/*.sNp files directly into run_path
-        alongside the mesh/config - so those are matched and removed individually.
+        subtree is the deletion target. Elmer's SaveScalars/ResultOutputSolver write
+        bare filenames (no path prefix) in their .sif config, so Elmer resolves them
+        relative to the Mesh DB directory ("mesh" under run_path) rather than run_path
+        itself - confirmed against real runs (same resolution mechanism found for
+        thermal_results.vtu, and combine_snp.py itself expects "scalar_results" under
+        a "mesh" parent and writes the resulting .sNp file there too). run_path itself
+        is also checked, defensively, in case some variant writes there directly.
         """
         if self.MainWindow.PalaceMode:
             output_dir = find_output_dir(run_path, saved_values['model_basename'])
@@ -1494,12 +1498,14 @@ class CreateModelTab(CreateModelTabBase):
             targets = [output_dir]
         else:
             targets = []
-            if os.path.isdir(run_path):
-                for fn in os.listdir(run_path):
-                    full_path = os.path.join(run_path, fn)
+            for search_dir in (os.path.join(run_path, "mesh"), run_path):
+                if not os.path.isdir(search_dir):
+                    continue
+                for fn in os.listdir(search_dir):
+                    full_path = os.path.join(search_dir, fn)
                     if not os.path.isfile(full_path):
                         continue
-                    if fn in ("scalar_results.dat", "scalar_results.names") or \
+                    if fn in ("scalar_results", "scalar_results.names") or \
                        fn.startswith("fields") or re.search(r'\.s\d+p$', fn, re.IGNORECASE):
                         targets.append(full_path)
             if not targets:

--- a/src/setupEM/setupThermal.py
+++ b/src/setupEM/setupThermal.py
@@ -17,7 +17,7 @@
 ########################################################################
 
 
-import sys, json, os, pathlib, ast, webbrowser, argparse
+import sys, json, os, pathlib, ast, webbrowser, argparse, subprocess, shutil, glob
 import numpy as np
 import importlib.metadata
 import requests
@@ -53,12 +53,14 @@ if __package__ in (None, ""):
         FileDropLineEdit, FileInputTab, PythonHighlighter, CodeEditor,
         VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
     )
+    from thermal_results import build_thermal_summary, format_source_table, find_thermal_vtu
 else:
     from .setup_common import (
         EDIT_STYLE_OPTIONAL, EDIT_STYLE_REQUIRED, COMBO_STYLE_REQUIRED, COMBO_STYLE_OPTIONAL,
         FileDropLineEdit, FileInputTab, PythonHighlighter, CodeEditor,
         VectorWidget, PopUpWindow, CreateModelTabBase, MainWindowBase,
     )
+    from .thermal_results import build_thermal_summary, format_source_table, find_thermal_vtu
 
 
 '''
@@ -569,6 +571,83 @@ class CreateModelTab(CreateModelTabBase):
     are specific to this app.
     """
 
+    def __init__(self, MainWindow):
+        super().__init__(MainWindow)
+
+        # Tracks which action self.process is currently running, so on_finished() can tell a
+        # simulation run apart from a mesh-creation run (self.process is reused for both).
+        self._process_purpose = None
+
+        # "View in ParaView" is thermal-only (Palace/EM results are S-parameters, not a 3D
+        # field to open directly), added as its own row of the base class's buttons_grid so
+        # it lines up with Preview/Create Mesh/Start Simulation above, in the same Actions group.
+        row = self.buttons_grid.rowCount()
+        self.paraview_btn = QPushButton("🖼️ View in ParaView")
+        self.paraview_btn.clicked.connect(self.launch_paraview)
+        self.buttons_grid.addWidget(self.paraview_btn, row, 0)
+
+    def _append_thermal_results_summary(self):
+        # Parse thermal_results.dat / thermal_results.vtu and append a results summary
+        # to the log. Called from on_finished() after a real simulation run.
+        run_path = saved_values['sim_path'] + "/elmer_model/" + saved_values['model_basename'] + "_data"
+
+        # Heat sources first, then constant-temperature boundaries, regardless of the
+        # order they were added in the GUI.
+        rows = []
+        for thermal_object in thermal_objects.objects:
+            if isinstance(thermal_object, simulation_setup.heatsource):
+                rows.append(["Heat source", str(thermal_object.source_layernum),
+                             str(thermal_object.target_layername), f"{thermal_object.power} W"])
+        for thermal_object in thermal_objects.objects:
+            if isinstance(thermal_object, simulation_setup.constanttemp):
+                rows.append(["Const. temp", str(thermal_object.source_layernum),
+                             str(thermal_object.target_layername), f"{thermal_object.temp} K"])
+        source_lines = format_source_table(rows) if rows else None
+
+        summary = build_thermal_summary(run_path, source_lines=source_lines)
+        self.log_area.appendPlainText("\n" + summary + "\n")
+
+    def on_finished(self, exit_code, exit_status):
+        super().on_finished(exit_code, exit_status)
+        # Auto-append the results summary after a real simulation run (not after mesh creation)
+        if self._process_purpose == "run_simulation":
+            self._append_thermal_results_summary()
+
+    def launch_paraview(self):
+        run_path = saved_values['sim_path'] + "/elmer_model/" + saved_values['model_basename'] + "_data"
+        vtu_path = find_thermal_vtu(run_path)
+
+        if vtu_path is None:
+            self.log_area.appendPlainText(f"⚠️ No thermal results .vtu found yet under {run_path}\n")
+            return
+
+        paraview_exe = shutil.which("paraview")
+        if paraview_exe is None and os.name == "nt":
+            # Not on PATH: fall back to searching the usual install locations, newest first.
+            candidates = (
+                glob.glob(r"C:\Program Files\ParaView*\bin\paraview.exe")
+                + glob.glob(r"C:\Program Files (x86)\ParaView*\bin\paraview.exe")
+            )
+            if candidates:
+                paraview_exe = max(candidates, key=os.path.getmtime)
+
+        if paraview_exe is None:
+            self.log_area.appendPlainText(
+                "⚠️ ParaView not found on PATH. Install it, or add it to PATH, "
+                f"then open manually:\n{vtu_path}\n"
+            )
+            return
+
+        # Detached, non-blocking launch (like klayout_setupEM.py's setupEM launch) -- this is
+        # a fire-and-forget external GUI viewer, unrelated to self.process's solver-run lifecycle.
+        env = os.environ.copy()
+        env.pop("PYTHONHOME", None)
+        try:
+            subprocess.Popen([paraview_exe, vtu_path], env=env)
+            self.log_area.appendPlainText(f"Starting ParaView on {vtu_path} ...\n")
+        except OSError as e:
+            self.log_area.appendPlainText(f"⚠️ Failed to launch ParaView: {e}\n")
+
     def create_model(self):
         # Request all tabs to save values again,
         # which can do some update to saved_values
@@ -606,6 +685,7 @@ class CreateModelTab(CreateModelTabBase):
 
             # Run Python interpreter on that file
             python_exe = sys.executable  # Use the same Python interpreter
+            self._process_purpose = "create_mesh"
             self.process.start(python_exe, [pymodel_filename])
 
 
@@ -622,6 +702,7 @@ class CreateModelTab(CreateModelTabBase):
 
         # clear log
         self.log_area.clear()
+        self._process_purpose = "run_simulation"
 
         # try to start from output directory
         run_path = saved_values['sim_path'] + "/elmer_model/" + saved_values['model_basename'] + "_data"

--- a/src/setupEM/setupThermal.py
+++ b/src/setupEM/setupThermal.py
@@ -17,7 +17,7 @@
 ########################################################################
 
 
-import sys, json, os, pathlib, ast, webbrowser, argparse, subprocess, shutil, glob
+import sys, json, os, pathlib, ast, webbrowser, argparse
 import numpy as np
 import importlib.metadata
 import requests
@@ -616,37 +616,10 @@ class CreateModelTab(CreateModelTabBase):
     def launch_paraview(self):
         run_path = saved_values['sim_path'] + "/elmer_model/" + saved_values['model_basename'] + "_data"
         vtu_path = find_thermal_vtu(run_path)
-
-        if vtu_path is None:
-            self.log_area.appendPlainText(f"⚠️ No thermal results .vtu found yet under {run_path}\n")
-            return
-
-        paraview_exe = shutil.which("paraview")
-        if paraview_exe is None and os.name == "nt":
-            # Not on PATH: fall back to searching the usual install locations, newest first.
-            candidates = (
-                glob.glob(r"C:\Program Files\ParaView*\bin\paraview.exe")
-                + glob.glob(r"C:\Program Files (x86)\ParaView*\bin\paraview.exe")
-            )
-            if candidates:
-                paraview_exe = max(candidates, key=os.path.getmtime)
-
-        if paraview_exe is None:
-            self.log_area.appendPlainText(
-                "⚠️ ParaView not found on PATH. Install it, or add it to PATH, "
-                f"then open manually:\n{vtu_path}\n"
-            )
-            return
-
-        # Detached, non-blocking launch (like klayout_setupEM.py's setupEM launch) -- this is
-        # a fire-and-forget external GUI viewer, unrelated to self.process's solver-run lifecycle.
-        env = os.environ.copy()
-        env.pop("PYTHONHOME", None)
-        try:
-            subprocess.Popen([paraview_exe, vtu_path], env=env)
-            self.log_area.appendPlainText(f"Starting ParaView on {vtu_path} ...\n")
-        except OSError as e:
-            self.log_area.appendPlainText(f"⚠️ Failed to launch ParaView: {e}\n")
+        self._open_in_paraview(
+            [vtu_path] if vtu_path else [],
+            f"⚠️ No thermal results .vtu found yet under {run_path}\n"
+        )
 
     def create_model(self):
         # Request all tabs to save values again,

--- a/src/setupEM/setup_common.py
+++ b/src/setupEM/setup_common.py
@@ -32,7 +32,7 @@ mesh fields, the Python model code generator bodies) is intentionally left
 in setupEM.py / setupThermal.py, not here.
 """
 
-import sys, os, json, pathlib, ast, webbrowser, io, contextlib
+import sys, os, json, pathlib, ast, webbrowser, io, contextlib, subprocess, shutil, glob
 import xml.etree.ElementTree as ET
 import numpy as np
 import requests
@@ -1277,6 +1277,7 @@ class CreateModelTabBase(QWidget):
         self.process.readyReadStandardOutput.connect(self.on_stdout)
         self.process.readyReadStandardError.connect(self.on_stderr)
         self.process.finished.connect(self.on_finished)
+        self.process.errorOccurred.connect(self.on_process_error)
 
     def on_modelname_edit_done(self):
         # Model name edit field has changed
@@ -1297,6 +1298,64 @@ class CreateModelTabBase(QWidget):
     def on_finished(self, exit_code, exit_status):
         """Handle process completion."""
         self.log_area.appendPlainText(f"\n--- Process finished with exit code {exit_code} ---\n")
+
+    def on_process_error(self, error):
+        """Handle QProcess itself failing to launch or run - most importantly
+        FailedToStart (program not found, or not executable, e.g. a .bat with content
+        the current shell can't run). Without this, such failures were silent: none of
+        readyReadStandardOutput/readyReadStandardError/finished ever fire for a process
+        that never actually started, leaving the log blank with no indication anything
+        went wrong.
+        """
+        messages = {
+            QProcess.FailedToStart: "the program could not be started (not found, or not executable)",
+            QProcess.Crashed: "the process crashed",
+            QProcess.Timedout: "the process timed out",
+            QProcess.WriteError: "an error occurred while writing to the process",
+            QProcess.ReadError: "an error occurred while reading from the process",
+            QProcess.UnknownError: "an unknown error occurred",
+        }
+        detail = messages.get(error, f"error code {error}")
+        self.log_area.appendPlainText(f"\n⚠️ Process error: {detail}\n")
+
+    def _open_in_paraview(self, file_paths, not_found_message):
+        """Locate ParaView and open it on file_paths (a list of .pvd/.vtu paths), or
+        log not_found_message if file_paths is empty. Shared by setupEM.py (Palace
+        field dumps / Elmer EM fields) and setupThermal.py (thermal_results.vtu) -
+        each caller is responsible for finding its own result files and wording its
+        own "nothing found" message; this only handles locating/launching ParaView.
+        Detached, non-blocking launch (like klayout_setupEM.py's setupEM launch) -
+        this is a fire-and-forget external GUI viewer, unrelated to self.process's
+        solver-run lifecycle.
+        """
+        if not file_paths:
+            self.log_area.appendPlainText(not_found_message)
+            return
+
+        paraview_exe = shutil.which("paraview")
+        if paraview_exe is None and os.name == "nt":
+            # Not on PATH: fall back to searching the usual install locations, newest first.
+            candidates = (
+                glob.glob(r"C:\Program Files\ParaView*\bin\paraview.exe")
+                + glob.glob(r"C:\Program Files (x86)\ParaView*\bin\paraview.exe")
+            )
+            if candidates:
+                paraview_exe = max(candidates, key=os.path.getmtime)
+
+        if paraview_exe is None:
+            self.log_area.appendPlainText(
+                "⚠️ ParaView not found on PATH. Install it, or add it to PATH, "
+                "then open manually:\n" + "\n".join(file_paths) + "\n"
+            )
+            return
+
+        env = os.environ.copy()
+        env.pop("PYTHONHOME", None)
+        try:
+            subprocess.Popen([paraview_exe, *file_paths], env=env)
+            self.log_area.appendPlainText("Starting ParaView on:\n" + "\n".join(file_paths) + "\n")
+        except OSError as e:
+            self.log_area.appendPlainText(f"⚠️ Failed to launch ParaView: {e}\n")
 
     def browse_directory(self):
         directory = QFileDialog.getExistingDirectory(
@@ -1328,9 +1387,15 @@ class CreateModelTabBase(QWidget):
                 if "===" in model_basename:
                     model_basename = ""
 
-        # no simulator name prefix
-        model_basename = model_basename.replace('palace_', '')
-        model_basename = model_basename.replace('elmer_', '')
+        # Strip a stale simulator-name prefix left over from a different solver choice
+        # (e.g. "elmer_..." after switching to Palace mode) - but never strip a prefix
+        # that already matches the current choice, otherwise importing an existing
+        # model and reusing its filename would silently rename it to a different file
+        # (setupThermal has no PalaceMode attribute at all; it's always Elmer, so only
+        # a "palace_" prefix would ever be considered stale there).
+        palace_mode = getattr(self.MainWindow, 'PalaceMode', False)
+        mismatched_prefix = 'elmer_' if palace_mode else 'palace_'
+        model_basename = model_basename.replace(mismatched_prefix, '')
 
         self.modelname_edit.setText(model_basename)
 
@@ -1708,7 +1773,11 @@ class MainWindowBase(QMainWindow):
                             if import_key not in import_value:  # skip the section where key might appear in different context
                                 # get the internal name for this variable
                                 varname = import_mapping.get(import_key, '')
-                                if varname in ("fpoint", "fdump", "variable_overrides", "refined_cellsize_override"):
+                                if varname in ("fpoint", "fdump"):
+                                    # same Hz-in-code / GHz-in-GUI unit split as fstart/fstop/fstep below,
+                                    # just per-element since these are lists
+                                    saved_values[varname] = [f / 1e9 for f in ast.literal_eval(import_value)]
+                                elif varname in ("variable_overrides", "refined_cellsize_override"):
                                     saved_values[varname] = ast.literal_eval(import_value)
                                 elif varname in ["gds_filename", "XML_filename", "GdsFile", "SubstrateFile"]:
                                     # check if we have full path for files in imported Python script,

--- a/src/setupEM/thermal_results.py
+++ b/src/setupEM/thermal_results.py
@@ -1,0 +1,175 @@
+########################################################################
+#
+# Copyright 2025-2026 Volker Muehlhaus and IHP PDK Authors
+#
+# Licensed under the GNU General Public License, Version 3.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.gnu.org/licenses/gpl-3.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+########################################################################
+
+"""Parse Elmer thermal solver output (thermal_results.dat / thermal_results.vtu)
+into a human-readable summary for the setupThermal "Create Model" log. No Qt
+dependency, so this can be exercised standalone against real Elmer output
+directories.
+"""
+
+import os
+import glob
+
+import meshio
+
+# Elmer's Post File in util_elmer.py is written with "Coordinate Scaling = Real 1e-6"
+# applied on read-in (mesh coordinates in um are scaled down to meters for the solve),
+# so node coordinates recovered from the .vtu are in meters and need to be scaled back
+# up to um to match the layout's native units.
+_METERS_TO_UM = 1e6
+
+
+def _candidate_dirs(run_path):
+    # util_elmer.py writes "Filename = ../thermal_results.dat" and
+    # "Post File = ../thermal_results.vtu", which reads as "one level above run_path"
+    # -- but Elmer actually resolves both relative to the Mesh DB directory ("mesh"
+    # under run_path, per "Mesh DB \"mesh\" \".\"" in the .sif), so "../" cancels back
+    # out to run_path itself (confirmed via thermal_results.dat.names: "Metadata for
+    # SaveScalars file: mesh/../thermal_results.dat"). run_path is therefore the real
+    # location; its parent is kept as a defensive fallback for other Elmer builds/versions.
+    run_path = os.path.normpath(run_path)
+    return [run_path, os.path.dirname(run_path)]
+
+
+def find_thermal_dat(run_path):
+    """Return the path to thermal_results.dat, or None if it doesn't exist yet."""
+    for d in _candidate_dirs(run_path):
+        path = os.path.join(d, "thermal_results.dat")
+        if os.path.isfile(path):
+            return path
+    return None
+
+
+def find_thermal_vtu(run_path):
+    """Return the path to the thermal results .vtu file, or None if it doesn't exist yet.
+
+    Elmer's Post File writer appends a timestep suffix (e.g. thermal_results_t0001.vtu)
+    even for a single steady-state solve, so this globs rather than matching a fixed name;
+    if more than one is found (re-run, or a multi-iteration solve), the most recently
+    written one wins.
+    """
+    matches = []
+    for d in _candidate_dirs(run_path):
+        matches += glob.glob(os.path.join(d, "thermal_results*.vtu"))
+    if not matches:
+        return None
+    return max(matches, key=os.path.getmtime)
+
+
+def read_minmax_temperature(run_path):
+    """Return (t_min, t_max) from thermal_results.dat, or None if missing/unparsable."""
+    path = find_thermal_dat(run_path)
+    if path is None:
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            lines = [line.strip() for line in f if line.strip()]
+        if not lines:
+            return None
+        # SaveScalars writes one row per solver call; steady-state thermal is a single
+        # solve, but take the last line defensively in case Elmer ever appends more.
+        values = [float(v) for v in lines[-1].split()]
+        if len(values) < 2:
+            return None
+        # Column order is fixed by our own .sif generation: Operator 1 = min, Operator 2 = max.
+        return values[0], values[1]
+    except (OSError, ValueError):
+        return None
+
+
+def find_max_temperature_location(run_path):
+    """Return (x, y, z) in um of the mesh node with the highest temperature, or None
+    if the thermal results .vtu doesn't exist yet or can't be read/parsed.
+    """
+    path = find_thermal_vtu(run_path)
+    if path is None:
+        return None
+    try:
+        mesh = meshio.read(path)
+        temp_key = next(
+            (key for key in mesh.point_data if "temp" in key.lower()),
+            None,
+        )
+        if temp_key is None:
+            return None
+        temperature = mesh.point_data[temp_key]
+        max_index = temperature.argmax()
+        x, y, z = mesh.points[max_index]
+        return x * _METERS_TO_UM, y * _METERS_TO_UM, z * _METERS_TO_UM
+    except Exception:
+        # Any read/parse failure (unsupported VTU variant, half-written file while a
+        # simulation is still running, etc.) should never block the min/max summary.
+        return None
+
+
+_SOURCE_TABLE_HEADERS = ["Type", "GDS Layer", "Target Layer", "Value"]
+
+
+def format_source_table(rows):
+    """Format (type, gds_layer, target_layer, value) string rows into an aligned table,
+    same layout style as palace_results.py's AMR results table. The caller decides row
+    order (heat sources first, then constant-temperature boundaries, per setupThermal.py).
+    """
+    headers = _SOURCE_TABLE_HEADERS
+    widths = [max(len(headers[i]), *(len(r[i]) for r in rows)) for i in range(len(headers))]
+
+    def fmt_row(cells):
+        return " | ".join(
+            cell.rjust(widths[i]) if i == len(cells) - 1 else cell.ljust(widths[i])
+            for i, cell in enumerate(cells)
+        )
+
+    lines = [fmt_row(headers), "-+-".join("-" * w for w in widths)]
+    lines += [fmt_row(row) for row in rows]
+    return lines
+
+
+def build_thermal_summary(run_path, source_lines=None):
+    """Return a formatted multi-line summary of Elmer thermal results found relative
+    to run_path (the case.sif working directory), or an explanatory message if
+    nothing is there yet.
+
+    source_lines, if given, is a list of pre-formatted strings describing the model's
+    heat sources / constant-temperature boundaries (e.g. str(heatsource_instance)) --
+    this module only knows about Elmer's output files, not the GUI's in-memory model,
+    so the caller supplies these rather than this module importing simulation_setup.
+    """
+    minmax = read_minmax_temperature(run_path)
+    if minmax is None:
+        return (f"No thermal results found yet (expected thermal_results.dat under {run_path}) "
+                 "-- has the simulation finished?")
+    t_min, t_max = minmax
+
+    location = find_max_temperature_location(run_path)
+    if location is not None:
+        x, y, z = location
+        location_line = f"Hotspot location  : x={x:.3f} um  y={y:.3f} um  z={z:.3f} um"
+    else:
+        location_line = "Hotspot location  : n/a (see thermal_results.vtu)"
+
+    lines = ["=== Thermal results ==="]
+    if source_lines:
+        lines.extend(source_lines)
+        lines.append("-" * 40)
+    lines += [
+        f"Min temperature   : {t_min:.2f} K",
+        f"Max temperature   : {t_max:.2f} K",
+        location_line,
+        "=" * 40,
+    ]
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Add mesh-refinement override editor,
- Add prompt on .py-model import asking whether to reuse the imported file's own output path/name, and several import/consistency fixes (cellname/variable_overrides being dropped, simulator mode not persisted, a JSON-load crash with per-side air margins)
- Add drag & drop support for *.simcfg/*.tsimcfg files
- AMR convergence-metric and error-indicator cleanup, mirroring the same changes in gds2palace_ihp_sg13g2
- Add a thermal results summary (min/max temperature, hotspot X/Y/Z) and a "View in ParaView" button to setupThermal after each Elmer thermal solve
- Add a "View fields in Paraview..." button (Palace fdump / Elmer EM field-dump output) to setupEM, shown only once fdump is set; renamed "View Results..." to "View S-Parameters..." for clarity
- Fix several Elmer EM launch bugs on Windows
- Fix Elmer mode not being detected when importing a .py model 
- Fix stale Elmer EM results (scalar_results, fields*, .sNp) never being offered for cleanup before a new run
- Fix importing an existing .py model and reusing its filename silently renaming the output to a different file, and fdump/fpoint showing raw Hz values instead of GHz after import

## Test plan
- [x] Verified Elmer mode is now correctly detected on import, for both `create_elmer(...)` and `settings['elmer'] = True` styles
- [x] Verified the "View fields in Paraview..." button appears/hides correctly as fdump is set/cleared, in both solver modes
- [x] Verified Elmer EM launches successfully on Windows via a real ElmerSolver run, including the MPI-availability check
- [x] Verified stale-results cleanup now finds real result files in run_path/mesh/ without touching mesh/config files needed for the rerun
- [x] Manual regression pass on the mesh-refinement override editor and drag & drop for *.simcfg files

🤖 Generated with [Claude Code](https://claude.com/claude-code)