### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/src/setupEM/__init__.py
+++ b/src/setupEM/__init__.py
@@ -24,4 +24,4 @@ A Python tool for EM setup using gds2palace.
 from .setupEM import main
 
 __all__ = ["main"]
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
## Summary
- Bump `__version__` to 0.6.1 - 0.6.0 is already merged upstream (#22) and published on PyPI, so a fresh version is needed for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)